### PR TITLE
ci: setup e2e tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        containers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+        containers: [1, 2, 3, 4] # 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
     name: Testing e2e in worker ${{ matrix.containers }}
     if: github.event.pull_request.draft == false
     steps:


### PR DESCRIPTION
Setup CI for e2e testing with Cypress.

Supported e2e tests:

- [ ] `integration/`
  - [x] `accessibilite`
  - [x] `homepage`
  - [x] `about`
  - [ ] `group`
  - [x] `news`
  - [ ] `personas`
- [ ] `pages/`
  - [ ] `groupes`
  - [ ] `simulations`
- [ ] `test-completion/`
  - [ ] `default`
  - [ ] `questions-order`
  - [ ] `url-redirection`

## Changelog

* Setup Cypress in `cypress.config.js`
* New workflow: `e2e.yaml`
* Change `moduleResolution` to `node` in the `tsconfig` file