### PR TITLE
Refactor(pulicodes-state): code review + refactoring

### DIFF
--- a/src/components/form/Question.tsx
+++ b/src/components/form/Question.tsx
@@ -8,6 +8,7 @@ import NumberInput from '@/components/form/question/NumberInput'
 import Suggestions from '@/components/form/question/Suggestions'
 import { DEFAULT_FOCUS_ELEMENT_ID } from '@/constants/accessibility'
 import { useRule } from '@/publicodes-state'
+import { NGCQuestionType } from '@/publicodes-state/types'
 
 type Props = {
   question: string
@@ -28,17 +29,10 @@ export default function Question({ question }: Props) {
     activeNotifications,
   } = useRule(question)
 
-  return (
-    <>
-      <div className="mb-4">
-        <Label
-          question={question}
-          label={label}
-          description={description}
-          htmlFor={DEFAULT_FOCUS_ELEMENT_ID}
-        />
-        <Suggestions question={question} />
-        {type === 'number' && (
+  const getInput = (type?: NGCQuestionType) => {
+    switch (type) {
+      case 'number':
+        return (
           <NumberInput
             unit={unit}
             value={numericValue}
@@ -51,8 +45,9 @@ export default function Question({ question }: Props) {
             data-cypress-id={question}
             id={DEFAULT_FOCUS_ELEMENT_ID}
           />
-        )}
-        {type === 'boolean' && (
+        )
+      case 'boolean':
+        return (
           <BooleanInput
             value={value}
             setValue={(value) => setValue(value, question)}
@@ -61,8 +56,9 @@ export default function Question({ question }: Props) {
             label={label || ''}
             id={DEFAULT_FOCUS_ELEMENT_ID}
           />
-        )}
-        {type === 'choices' && (
+        )
+      case 'choices':
+        return (
           <ChoicesInput
             question={question}
             choices={choices}
@@ -73,8 +69,20 @@ export default function Question({ question }: Props) {
             label={label || ''}
             id={DEFAULT_FOCUS_ELEMENT_ID}
           />
-        )}
-        {type === 'mosaic' && <Mosaic question={question} />}
+        )
+      case 'mosaic':
+        return <Mosaic question={question} />
+      default:
+        return null
+    }
+  }
+
+  return (
+    <>
+      <div className="mb-4">
+        <Label question={question} label={label} description={description} />
+        <Suggestions question={question} />
+        {getInput(type)}
       </div>
       {assistance ? (
         <Assistance question={question} assistance={assistance} />

--- a/src/hooks/useRules.ts
+++ b/src/hooks/useRules.ts
@@ -35,7 +35,8 @@ export function useRules({ lang, region, isOptim = true }: Props) {
         .then((res) => res.data as unknown),
     {
       keepPreviousData: true,
-      // When we work locally on the model we want the rules to be updated as much as possible (on window focus and every 3 seconds)
+      // When we work locally on the model we want the rules to be updated as
+      // much as possible (on window focus and every 3 seconds)
       refetchOnWindowFocus: process.env.NEXT_PUBLIC_LOCAL_DATA_SERVER
         ? true
         : false,

--- a/src/publicodes-state/README.md
+++ b/src/publicodes-state/README.md
@@ -1,15 +1,25 @@
 # Publicodes State
 
-Cette librairie met à disposition des hooks React permettant de gérer le state d'un utilisateur de Nos Gestes Climat et ses simulations associées.
+Cette librairie met à disposition des hooks React permettant de gérer le state
+d'un utilisateur de Nos Gestes Climat et ses simulations associées.
 
-Cette librairie souhaite permettre une façon simple et claire de modulariser le code de Nos Gestes Climat en permettant de séparer toute la logique utilisateur/formulaire/publicodes du reste du front-end. Cette séparation des préoccupations permet au front-end d'évoluer rapidement sans avoir à se soucier des complexités du moteur Publicodes.
+Cette librairie souhaite permettre une façon simple et claire de modulariser le
+code de Nos Gestes Climat en permettant de séparer toute la logique
+utilisateur/formulaire/publicodes du reste du front-end. Cette séparation des
+préoccupations permet au front-end d'évoluer rapidement sans avoir à se soucier
+des complexités du moteur Publicodes.
 
 Ce que cette librairie ne fait pas :
 
-- Chargement des fichiers de règles Publicodes. Un fichier de règle doit être fourni déjà chargé au provider de la librairie.
-- Régionalisation et internationalisation. Le fichier de règle étant fourni par le front-end, la librairie n'a aucune idée de la langue de celui-ci.
+- Chargement des fichiers de règles Publicodes. Un fichier de règle doit être
+fourni déjà chargé au provider de la librairie.
+- Régionalisation et internationalisation. Le fichier de règle étant fourni par
+le front-end, la librairie n'a aucune idée de la langue de celui-ci.
 
-La librairie propose trois providers et leurs hooks associés : un pour la gestion d'un utilisateur, un pour initialiser l'engine et la simulation (basé sur les infos de user) et le dernier pour la gestion d'un formulaire (basé sur la simulation).
+La librairie propose trois providers et leurs hooks associés : un pour la
+gestion d'un utilisateur, un pour initialiser l'engine et la simulation (basé
+sur les infos de user) et le dernier pour la gestion d'un formulaire (basé sur
+la simulation).
 
 ## Providers
 

--- a/src/publicodes-state/helpers/getIsMissing.ts
+++ b/src/publicodes-state/helpers/getIsMissing.ts
@@ -1,8 +1,8 @@
-import { Situation } from '../types'
+import { RuleName, Situation } from '../types'
 
 type Props = {
-  dottedName: string
-  questionsOfMosaic: string[]
+  dottedName: RuleName
+  questionsOfMosaic: RuleName[]
   situation: Situation
 }
 

--- a/src/publicodes-state/helpers/getQuestionsOfMosaic.ts
+++ b/src/publicodes-state/helpers/getQuestionsOfMosaic.ts
@@ -1,3 +1,5 @@
+import { RuleName } from '@/publicodes-state/types'
+
 type Props = {
   dottedName: RuleName
   everyMosaicChildWhoIsReallyInMosaic: RuleName[]

--- a/src/publicodes-state/helpers/getQuestionsOfMosaic.ts
+++ b/src/publicodes-state/helpers/getQuestionsOfMosaic.ts
@@ -1,12 +1,12 @@
 type Props = {
-  dottedName: string
-  everyMosaicChildWhoIsReallyInMosaic: string[]
+  dottedName: RuleName
+  everyMosaicChildWhoIsReallyInMosaic: RuleName[]
 }
 
 export default function getQuestionsOfMosaic({
   dottedName,
   everyMosaicChildWhoIsReallyInMosaic,
-}: Props): string[] {
+}: Props): RuleName[] {
   return (
     everyMosaicChildWhoIsReallyInMosaic.filter((mosaicChild) =>
       mosaicChild.includes(dottedName)

--- a/src/publicodes-state/helpers/getType.ts
+++ b/src/publicodes-state/helpers/getType.ts
@@ -1,21 +1,16 @@
-import { NGCEvaluatedNode, NGCRuleNode } from '../types'
+import { NGCEvaluatedNode, NGCQuestionType, NGCRuleNode } from '../types'
 
 type Props = {
   dottedName: string
   rule: NGCRuleNode | null | any // Model shenanigans: question alimentation . local . consommation is missing "formule"
   evaluation: NGCEvaluatedNode | null
 }
+
 export default function getType({
   dottedName,
   rule,
   evaluation,
-}: Props):
-  | 'notQuestion'
-  | 'mosaic'
-  | 'choices'
-  | 'boolean'
-  | 'number'
-  | undefined {
+}: Props): NGCQuestionType | undefined {
   if (!rule || !evaluation) return
 
   if (!rule.rawNode.question) {

--- a/src/publicodes-state/helpers/getType.ts
+++ b/src/publicodes-state/helpers/getType.ts
@@ -1,8 +1,15 @@
-import { NGCEvaluatedNode, NGCQuestionType, NGCRuleNode } from '../types'
+import {
+  NGCEvaluatedNode,
+  NGCQuestionType,
+  NGCRuleNode,
+  RuleName,
+} from '../types'
 
 type Props = {
-  dottedName: string
-  rule: NGCRuleNode | null | any // Model shenanigans: question alimentation . local . consommation is missing "formule"
+  dottedName: RuleName
+  // Model shenanigans: question alimentation . local . consommation is missing "formule"
+  // NOTE(@EmileRolley): I don't get why it's a problem?
+  rule: NGCRuleNode | null | any
   evaluation: NGCEvaluatedNode | null
 }
 
@@ -11,7 +18,9 @@ export default function getType({
   rule,
   evaluation,
 }: Props): NGCQuestionType | undefined {
-  if (!rule || !evaluation) return
+  if (!rule || !evaluation) {
+    return undefined
+  }
 
   if (!rule.rawNode.question) {
     return 'notQuestion'

--- a/src/publicodes-state/helpers/safeEvaluateHelper.ts
+++ b/src/publicodes-state/helpers/safeEvaluateHelper.ts
@@ -4,12 +4,11 @@ export const safeEvaluateHelper = (
   rule: string,
   engineUsed: Engine
 ): NGCEvaluatedNode | null => {
-  let evaluation = null
   try {
-    evaluation = engineUsed.evaluate(rule)
+    return engineUsed.evaluate(rule)
   } catch (error) {
     // TODO: Sending error to Sentry breaks the app
     console.warn(error)
   }
-  return evaluation
+  return null
 }

--- a/src/publicodes-state/helpers/safeEvaluateHelper.ts
+++ b/src/publicodes-state/helpers/safeEvaluateHelper.ts
@@ -1,7 +1,7 @@
-import { Engine, NGCEvaluatedNode } from '../types'
+import { Engine, NGCEvaluatedNode, RuleName } from '../types'
 
 export const safeEvaluateHelper = (
-  rule: string,
+  rule: RuleName,
   engineUsed: Engine
 ): NGCEvaluatedNode | null => {
   try {

--- a/src/publicodes-state/helpers/safeGetSituation.ts
+++ b/src/publicodes-state/helpers/safeGetSituation.ts
@@ -1,18 +1,19 @@
-import { NodeValue, Situation } from '../types'
+import { RuleName, Situation } from '../types'
 
+// FIXME(@EmileRolley): the function should return a Situation
 export const safeGetSituation = ({
   situation,
   everyRules,
 }: {
   situation: Situation
-  everyRules: string[]
+  everyRules: RuleName[]
 }): any =>
   everyRules
-    .filter((rule: string) => situation[rule] || situation[rule] === 0)
+    .filter((rule: RuleName) => situation[rule] || situation[rule] === 0)
     .reduce(
-      (accumulator: Record<string, NodeValue>, currentValue: string) => ({
-        ...accumulator,
-        [currentValue]: situation[currentValue],
+      (situationAcc: Situation, currentRule: RuleName) => ({
+        ...situationAcc,
+        [currentRule]: situation[currentRule],
       }),
       {}
     )

--- a/src/publicodes-state/hooks/useActions/index.ts
+++ b/src/publicodes-state/hooks/useActions/index.ts
@@ -1,13 +1,15 @@
 'use client'
 
+import { NodeValue } from '@/publicodes-state/types'
 import { useContext, useMemo } from 'react'
 import { useEngine } from '../..'
 import simulationContext from '../../providers/simulationProvider/context'
 
-type ActionObject = {
+type EvaluatedAction = {
   dottedName: string
-  value: number
+  value: NodeValue
 }
+
 /**
  * A hook to help with the actions display and processing.
  *
@@ -26,10 +28,13 @@ export default function useActions() {
           dottedName: action,
           value: getValue(action),
         }))
-        .sort((a: ActionObject, b: ActionObject) =>
-          a.value > b.value ? -1 : 1
-        )
-        .map((actionObject: ActionObject) => actionObject.dottedName),
+        .sort((a: EvaluatedAction, b: EvaluatedAction) => {
+          if (typeof a.value === 'number' && typeof b.value === 'number') {
+            return a.value - b.value
+          }
+          // NOTE(@EmileRolley): what should be done if the values are not numbers?
+        })
+        .map((actionObject: EvaluatedAction) => actionObject.dottedName),
     [engine, getValue]
   )
 

--- a/src/publicodes-state/hooks/useDisposableEngine/index.ts
+++ b/src/publicodes-state/hooks/useDisposableEngine/index.ts
@@ -2,7 +2,7 @@ import Engine from 'publicodes'
 import { useMemo } from 'react'
 import { safeEvaluateHelper } from '../../helpers/safeEvaluateHelper'
 import { safeGetSituation } from '../../helpers/safeGetSituation'
-import { Situation } from '../../types'
+import { NGCRules, Situation } from '../../types'
 
 type Props = {
   rules?: NGCRules

--- a/src/publicodes-state/hooks/useDisposableEngine/index.ts
+++ b/src/publicodes-state/hooks/useDisposableEngine/index.ts
@@ -20,7 +20,10 @@ export default function useDisposableEngine({ rules, situation }: Props) {
   const engine = useMemo(
     () =>
       new Engine(rules).setSituation(
-        safeGetSituation({ situation, everyRules: Object.keys(rules ?? {}) })
+        safeGetSituation({
+          situation,
+          everyRules: Object.keys(rules ?? {}),
+        })
       ),
     [rules, situation]
   )

--- a/src/publicodes-state/hooks/useDisposableEngine/index.ts
+++ b/src/publicodes-state/hooks/useDisposableEngine/index.ts
@@ -5,19 +5,22 @@ import { safeGetSituation } from '../../helpers/safeGetSituation'
 import { Situation } from '../../types'
 
 type Props = {
-  rules?: any
+  rules?: NGCRules
   situation: Situation
 }
+
 /**
- * A hook that set up a separate engine to use for calculation.
+ * A hook that set up a separate engine, only used to evaluate a specific rule.
  *
- * Very ressource intensive. Use with caution
+ * @note There is no impact on the state current application's state.
+ *
+ * @note It's very ressource intensive, you should use it with caution.
  */
 export default function useDisposableEngine({ rules, situation }: Props) {
   const engine = useMemo(
     () =>
       new Engine(rules).setSituation(
-        safeGetSituation({ situation, everyRules: Object.keys(rules) })
+        safeGetSituation({ situation, everyRules: Object.keys(rules ?? {}) })
       ),
     [rules, situation]
   )
@@ -32,11 +35,11 @@ export default function useDisposableEngine({ rules, situation }: Props) {
   const getValue = (dottedName: string) =>
     safeEvaluate(dottedName, engine)?.nodeValue
 
-  const updateSituation = (newSituation: any) => {
+  const updateSituation = (newSituation: Situation) => {
     engine.setSituation(
       safeGetSituation({
         situation: newSituation,
-        everyRules: Object.keys(rules),
+        everyRules: Object.keys(rules ?? {}),
       })
     )
   }

--- a/src/publicodes-state/hooks/useEngine/index.ts
+++ b/src/publicodes-state/hooks/useEngine/index.ts
@@ -5,7 +5,11 @@ import { NodeValue } from '../../types'
 /**
  * A hook that make available some basic functions on the engine (and the engine itself).
  *
- * It should only be used when it is needed to compare rules between them. If not, useRule should be used
+ * It should only be used when it is needed to compare rules between them.
+ * If not, useRule should be used.
+ *
+ * NOTE(@EmileRolley): could you be more a bit more specific about the usage of
+ * [useEngine] instead of [useRule]?
  */
 export default function useEngine() {
   const { engine, safeEvaluate, safeGetRule, updateSituation } =
@@ -22,7 +26,7 @@ export default function useEngine() {
   const getCategory = (dottedName: string): string => dottedName.split(' . ')[0]
 
   const checkIfValid = (dottedName: string): boolean =>
-    safeGetRule(dottedName) ? true : false
+    safeGetRule(dottedName) !== null
 
   return {
     engine,

--- a/src/publicodes-state/hooks/useRule/index.ts
+++ b/src/publicodes-state/hooks/useRule/index.ts
@@ -2,8 +2,8 @@
 
 import { captureException } from '@sentry/react'
 import { useContext, useMemo } from 'react'
-import simulationContext from '../../providers/simulationProvider/context'
-import { NGCEvaluatedNode, NGCRuleNode } from '../../types'
+import simulationContext from '../simulationProvider/context'
+import { NGCEvaluatedNode, NGCRuleNode, RuleName } from '../types'
 import useChoices from './useChoices'
 import useContent from './useContent'
 import useMissing from './useMissing'
@@ -18,7 +18,7 @@ import useValue from './useValue'
  * It should ALWAYS be used to access a rule
  * (unless we need to compare mutliples rules with useEngine).
  */
-export default function useRule(dottedName: string) {
+export default function useRule(dottedName: RuleName) {
   const {
     engine,
     safeGetRule,

--- a/src/publicodes-state/hooks/useRule/index.ts
+++ b/src/publicodes-state/hooks/useRule/index.ts
@@ -13,9 +13,10 @@ import useType from './useType'
 import useValue from './useValue'
 
 /**
- * A hook to get and set every information about a specific rule
+ * A hook to get and set every information about a specific rule.
  *
- * It should ALWAYS be used to access a rule (unless we need to compare mutliples rules with useEngine)
+ * It should ALWAYS be used to access a rule
+ * (unless we need to compare mutliples rules with useEngine).
  */
 export default function useRule(dottedName: string) {
   const {

--- a/src/publicodes-state/hooks/useRule/index.ts
+++ b/src/publicodes-state/hooks/useRule/index.ts
@@ -2,8 +2,8 @@
 
 import { captureException } from '@sentry/react'
 import { useContext, useMemo } from 'react'
-import simulationContext from '../simulationProvider/context'
-import { NGCEvaluatedNode, NGCRuleNode, RuleName } from '../types'
+import simulationContext from '../../providers/simulationProvider/context'
+import { NGCEvaluatedNode, NGCRuleNode, RuleName } from '../../types'
 import useChoices from './useChoices'
 import useContent from './useContent'
 import useMissing from './useMissing'

--- a/src/publicodes-state/hooks/useRule/useChoices.ts
+++ b/src/publicodes-state/hooks/useRule/useChoices.ts
@@ -4,11 +4,13 @@ import { useMemo } from 'react'
 import { NGCRuleNode } from '../../types'
 
 type Props = {
-  rule: NGCRuleNode | null | any // Model shenanigans: question alimentation . local . consommation is missing "formule"
+  // Model shenanigans: question alimentation . local . consommation is missing "formule"
+  // NOTE(@EmileRolley): I don't get why it's a problem?
+  rule: NGCRuleNode | null | any
   type: string | undefined
 }
 
-export default function useChoices({ rule, type }: Props) {
+export default function useChoices({ rule, type }: Props): string[] {
   const choices = useMemo<string[]>(() => {
     if (type === 'choices') {
       // Model shenanigans: sometimes "une possibilité" is in rawNode, sometimes it is in formule

--- a/src/publicodes-state/hooks/useRule/useContent.ts
+++ b/src/publicodes-state/hooks/useRule/useContent.ts
@@ -1,12 +1,12 @@
 'use client'
 
 import { useMemo } from 'react'
-import { NGCRuleNode, Suggestion } from '../../types'
+import { NGCRuleNode, RuleName, Suggestion } from '../types'
 
 type Props = {
-  dottedName: string
+  dottedName: RuleName
   rule: NGCRuleNode | null
-  safeGetRule: (rule: string) => NGCRuleNode | null
+  safeGetRule: (rule: RuleName) => NGCRuleNode | null
 }
 
 export default function useContent({ dottedName, rule, safeGetRule }: Props) {

--- a/src/publicodes-state/hooks/useRule/useContent.ts
+++ b/src/publicodes-state/hooks/useRule/useContent.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useMemo } from 'react'
-import { NGCRuleNode, RuleName, Suggestion } from '../types'
+import { NGCRuleNode, RuleName, Suggestion } from '../../types'
 
 type Props = {
   dottedName: RuleName

--- a/src/publicodes-state/hooks/useRule/useMissing.ts
+++ b/src/publicodes-state/hooks/useRule/useMissing.ts
@@ -1,8 +1,8 @@
 'use client'
 
 import { useMemo } from 'react'
-import getIsMissing from '../helpers/getIsMissing'
-import { RuleName, Situation } from '../types'
+import getIsMissing from '../../helpers/getIsMissing'
+import { RuleName, Situation } from '../../types'
 
 type Props = {
   dottedName: RuleName

--- a/src/publicodes-state/hooks/useRule/useMissing.ts
+++ b/src/publicodes-state/hooks/useRule/useMissing.ts
@@ -1,20 +1,18 @@
 'use client'
 
 import { useMemo } from 'react'
-import getIsMissing from '../../helpers/getIsMissing'
-import { Situation } from '../../types'
+import getIsMissing from '../helpers/getIsMissing'
+import { RuleName, Situation } from '../types'
 
 type Props = {
-  dottedName: string
-  questionsOfMosaic: string[]
+  dottedName: RuleName
+  questionsOfMosaic: RuleName[]
   situation: Situation
 }
 
-export default function useValue({
-  dottedName,
-  situation,
-  questionsOfMosaic,
-}: Props) {
+export default function ({ dottedName, situation, questionsOfMosaic }: Props): {
+  isMissing: boolean
+} {
   const isMissing = useMemo(
     () =>
       getIsMissing({

--- a/src/publicodes-state/hooks/useRule/useMosaic.ts
+++ b/src/publicodes-state/hooks/useRule/useMosaic.ts
@@ -1,18 +1,19 @@
 'use client'
 
+import { RuleName } from '@/publicodes-state/types'
 import { useMemo } from 'react'
 import getQuestionsOfMosaic from '../../helpers/getQuestionsOfMosaic'
 
 type Props = {
-  dottedName: string
-  everyMosaicChildWhoIsReallyInMosaic: string[]
+  dottedName: RuleName
+  everyMosaicChildWhoIsReallyInMosaic: RuleName[]
 }
 
 export default function useMosaic({
   dottedName,
   everyMosaicChildWhoIsReallyInMosaic,
 }: Props) {
-  const questionsOfMosaic = useMemo<string[]>(
+  const questionsOfMosaic = useMemo<RuleName[]>(
     () =>
       getQuestionsOfMosaic({
         dottedName,
@@ -21,7 +22,7 @@ export default function useMosaic({
     [dottedName, everyMosaicChildWhoIsReallyInMosaic]
   )
 
-  const parent = useMemo<string>(() => {
+  const parent = useMemo<RuleName>(() => {
     const dottedNameArray = dottedName.split(' . ')
     dottedNameArray.pop()
     return dottedNameArray.join(' . ')

--- a/src/publicodes-state/hooks/useRule/useNotifications.ts
+++ b/src/publicodes-state/hooks/useRule/useNotifications.ts
@@ -1,10 +1,10 @@
 'use client'
 
 import { useMemo } from 'react'
-import { NGCEvaluatedNode, Situation } from '../../types'
+import { NGCEvaluatedNode, RuleName, Situation } from '../types'
 
 type Props = {
-  dottedName: string
+  dottedName: RuleName
   everyNotifications: string[]
   safeEvaluate: (rule: string) => NGCEvaluatedNode | null
   situation: Situation

--- a/src/publicodes-state/hooks/useRule/useNotifications.ts
+++ b/src/publicodes-state/hooks/useRule/useNotifications.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useMemo } from 'react'
-import { NGCEvaluatedNode, RuleName, Situation } from '../types'
+import { NGCEvaluatedNode, RuleName, Situation } from '../../types'
 
 type Props = {
   dottedName: RuleName

--- a/src/publicodes-state/hooks/useRule/useType.ts
+++ b/src/publicodes-state/hooks/useRule/useType.ts
@@ -2,15 +2,23 @@
 
 import { useMemo } from 'react'
 import getType from '../helpers/getType'
-import { NGCEvaluatedNode, NGCQuestionType, NGCRuleNode } from '../types'
+import {
+  NGCEvaluatedNode,
+  NGCQuestionType,
+  NGCRuleNode,
+  RuleName,
+} from '../types'
 
 type Props = {
-  dottedName: string
+  dottedName: RuleName
   rule: NGCRuleNode | null
   evaluation: NGCEvaluatedNode | null
 }
 
-export default function useType({ dottedName, rule, evaluation }: Props) {
+export default function useType({ dottedName, rule, evaluation }: Props): {
+  type: NGCQuestionType | undefined
+  getType: (dottedName: Props) => NGCQuestionType | undefined
+} {
   // Model shenanigans
 
   const type = useMemo<NGCQuestionType | undefined>(() => {

--- a/src/publicodes-state/hooks/useRule/useType.ts
+++ b/src/publicodes-state/hooks/useRule/useType.ts
@@ -1,8 +1,8 @@
 'use client'
 
 import { useMemo } from 'react'
-import getType from '../../helpers/getType'
-import { NGCEvaluatedNode, NGCRuleNode } from '../../types'
+import getType from '../helpers/getType'
+import { NGCEvaluatedNode, NGCQuestionType, NGCRuleNode } from '../types'
 
 type Props = {
   dottedName: string
@@ -13,9 +13,7 @@ type Props = {
 export default function useType({ dottedName, rule, evaluation }: Props) {
   // Model shenanigans
 
-  const type = useMemo<
-    'notQuestion' | 'mosaic' | 'choices' | 'boolean' | 'number' | undefined
-  >(() => {
+  const type = useMemo<NGCQuestionType | undefined>(() => {
     return getType({ dottedName, rule, evaluation })
   }, [dottedName, rule, evaluation])
 

--- a/src/publicodes-state/hooks/useRule/useType.ts
+++ b/src/publicodes-state/hooks/useRule/useType.ts
@@ -1,13 +1,13 @@
 'use client'
 
 import { useMemo } from 'react'
-import getType from '../helpers/getType'
+import getType from '../../helpers/getType'
 import {
   NGCEvaluatedNode,
   NGCQuestionType,
   NGCRuleNode,
   RuleName,
-} from '../types'
+} from '../../types'
 
 type Props = {
   dottedName: RuleName

--- a/src/publicodes-state/hooks/useRule/useValue.ts
+++ b/src/publicodes-state/hooks/useRule/useValue.ts
@@ -7,15 +7,16 @@ import {
   NGCQuestionType,
   NGCRuleNode,
   NodeValue,
+  RuleName,
   Situation,
 } from '../types'
 type Props = {
-  dottedName: string
-  safeGetRule: (rule: string) => NGCRuleNode | null
-  safeEvaluate: (rule: string) => NGCEvaluatedNode | null
+  dottedName: RuleName
+  safeGetRule: (rule: RuleName) => NGCRuleNode | null
+  safeEvaluate: (rule: RuleName) => NGCEvaluatedNode | null
   evaluation: NGCEvaluatedNode | null
   type: NGCQuestionType | undefined
-  questionsOfMosaic: string[]
+  questionsOfMosaic: RuleName[]
   updateSituation: (situationToAdd: Situation) => Promise<void>
   addFoldedStep: (foldedStep: string) => void
 }

--- a/src/publicodes-state/hooks/useRule/useValue.ts
+++ b/src/publicodes-state/hooks/useRule/useValue.ts
@@ -1,19 +1,20 @@
 'use client'
 
 import { useMemo } from 'react'
-import getType from '../../helpers/getType'
+import getType from '../helpers/getType'
 import {
   NGCEvaluatedNode,
+  NGCQuestionType,
   NGCRuleNode,
   NodeValue,
   Situation,
-} from '../../types'
+} from '../types'
 type Props = {
   dottedName: string
   safeGetRule: (rule: string) => NGCRuleNode | null
   safeEvaluate: (rule: string) => NGCEvaluatedNode | null
   evaluation: NGCEvaluatedNode | null
-  type: string | undefined
+  type: NGCQuestionType | undefined
   questionsOfMosaic: string[]
   updateSituation: (situationToAdd: Situation) => Promise<void>
   addFoldedStep: (foldedStep: string) => void
@@ -32,21 +33,25 @@ export default function useValue({
   const value = useMemo<NodeValue>(() => evaluation?.nodeValue, [evaluation])
 
   const displayValue = useMemo<string | number>(() => {
-    if (type === 'choices') {
-      const stringValue = String(value)
-      return stringValue.startsWith("'")
-        ? stringValue.substring(1, stringValue.length - 1)
-        : stringValue
+    switch (type) {
+      case 'choices': {
+        const stringValue = String(value)
+        return stringValue.startsWith("'")
+          ? stringValue.substring(1, stringValue.length - 1)
+          : stringValue
+      }
+      case 'boolean':
+        return value === null || value === false || value === 'non' // Model shenanigans
+          ? 'non'
+          : 'oui'
+      case 'number':
+        return Number(value)
+      case 'mosaic':
+        return 'mosaic'
+      default:
+        // NOTE(@EmileRolley): I'm not sure what is the wanted behavior for undefined type or 'noQuestion'
+        return 'non défini'
     }
-    if (type === 'boolean') {
-      return value === null || value === false || value === 'non' // Model shenanigans
-        ? 'non'
-        : 'oui'
-    }
-    if (type === 'mosaic') {
-      return 'mosaic'
-    }
-    return Number(value)
   }, [value, type])
 
   const numericValue = useMemo<number>(

--- a/src/publicodes-state/hooks/useRule/useValue.ts
+++ b/src/publicodes-state/hooks/useRule/useValue.ts
@@ -1,7 +1,7 @@
 'use client'
 
 import { useMemo } from 'react'
-import getType from '../helpers/getType'
+import getType from '../../helpers/getType'
 import {
   NGCEvaluatedNode,
   NGCQuestionType,
@@ -9,7 +9,7 @@ import {
   NodeValue,
   RuleName,
   Situation,
-} from '../types'
+} from '../../types'
 type Props = {
   dottedName: RuleName
   safeGetRule: (rule: RuleName) => NGCRuleNode | null

--- a/src/publicodes-state/hooks/useTempEngine/index.ts
+++ b/src/publicodes-state/hooks/useTempEngine/index.ts
@@ -2,7 +2,7 @@ import { useContext } from 'react'
 import simulationContext from '../../providers/simulationProvider/context'
 
 /**
- * This is temporary and should be put to death as soon as possible
+ * FIXME: This is temporary and should be put to death as soon as possible
  */
 export default function useTempEngine() {
   const { safeEvaluate, rules, safeGetRule } =

--- a/src/publicodes-state/providers/simulationProvider/index.tsx
+++ b/src/publicodes-state/providers/simulationProvider/index.tsx
@@ -2,7 +2,7 @@
 
 import { PropsWithChildren } from 'react'
 
-import { Rules, Situation } from '../../types'
+import { RuleName, Rules, Situation } from '../types'
 import SimulationContext from './context'
 import useCategories from './useCategories'
 import useEngine from './useEngine'
@@ -29,7 +29,7 @@ type Props = {
   /**
    * Every answered questions of the current simulation
    */
-  foldedSteps: string[]
+  foldedSteps: RuleName[]
   /**
    * A function to add a question to the list of the answered questions of the current simulation
    */
@@ -37,11 +37,11 @@ type Props = {
   /**
    * The order in wich we should display the categories
    */
-  categoryOrder: string[]
+  categoryOrder: RuleName[]
   /**
    * The root rule of the simulation
    */
-  root?: string
+  root?: RuleName
 }
 
 export default function SimulationProvider({
@@ -63,7 +63,10 @@ export default function SimulationProvider({
     everyQuestions,
     everyNotifications,
     everyMosaicChildWhoIsReallyInMosaic,
-  } = useRules({ engine: pristineEngine })
+  } = useRules({
+    // NOTE(@EmileRolley): why do we need to use a engine here instead of provided rules?
+    engine: pristineEngine,
+  })
 
   const { situation, updateSituation, initialized } = useSituation({
     engine,
@@ -104,7 +107,8 @@ export default function SimulationProvider({
         everyMosaicChildWhoIsReallyInMosaic,
         categories,
         subcategories,
-      }}>
+      }}
+    >
       {initialized ? children : null}
     </SimulationContext.Provider>
   )

--- a/src/publicodes-state/providers/simulationProvider/index.tsx
+++ b/src/publicodes-state/providers/simulationProvider/index.tsx
@@ -2,7 +2,7 @@
 
 import { PropsWithChildren } from 'react'
 
-import { RuleName, Rules, Situation } from '../types'
+import { RuleName, Rules, Situation } from '../../types'
 import SimulationContext from './context'
 import useCategories from './useCategories'
 import useEngine from './useEngine'
@@ -107,8 +107,7 @@ export default function SimulationProvider({
         everyMosaicChildWhoIsReallyInMosaic,
         categories,
         subcategories,
-      }}
-    >
+      }}>
       {initialized ? children : null}
     </SimulationContext.Provider>
   )

--- a/src/publicodes-state/providers/simulationProvider/useEngine.ts
+++ b/src/publicodes-state/providers/simulationProvider/useEngine.ts
@@ -1,7 +1,7 @@
 import Engine from 'publicodes'
 import { useMemo } from 'react'
-import { safeEvaluateHelper } from '../helpers/safeEvaluateHelper'
-import { NGCEvaluatedNode, NGCRuleNode, RuleName, Rules } from '../types'
+import { safeEvaluateHelper } from '../../helpers/safeEvaluateHelper'
+import { NGCEvaluatedNode, NGCRuleNode, RuleName, Rules } from '../../types'
 
 /**
  * Initiate the engine based on the rules we pass

--- a/src/publicodes-state/providers/simulationProvider/useEngine.ts
+++ b/src/publicodes-state/providers/simulationProvider/useEngine.ts
@@ -8,7 +8,8 @@ import { NGCEvaluatedNode, NGCRuleNode, Rules } from '../../types'
  *
  * Also return safeEvaluate and safeGetRule wich catch errors if dottedName is invalid
  *
- * And a pristine engine wich can be used to assess rules without any situation (for exemple, we can reliably sort the subcategories this way)
+ * And a pristine engine wich can be used to evaluate rules without any situation
+ * (for exemple, we can reliably sort the subcategories this way)
  */
 export default function useEngine(rules: Rules) {
   const engine = useMemo<Engine>(

--- a/src/publicodes-state/providers/simulationProvider/useEngine.ts
+++ b/src/publicodes-state/providers/simulationProvider/useEngine.ts
@@ -1,7 +1,7 @@
 import Engine from 'publicodes'
 import { useMemo } from 'react'
-import { safeEvaluateHelper } from '../../helpers/safeEvaluateHelper'
-import { NGCEvaluatedNode, NGCRuleNode, Rules } from '../../types'
+import { safeEvaluateHelper } from '../helpers/safeEvaluateHelper'
+import { NGCEvaluatedNode, NGCRuleNode, RuleName, Rules } from '../types'
 
 /**
  * Initiate the engine based on the rules we pass
@@ -26,20 +26,19 @@ export default function useEngine(rules: Rules) {
 
   const pristineEngine = useMemo(() => engine.shallowCopy(), [engine])
 
-  const safeEvaluate = useMemo<(rule: string) => NGCEvaluatedNode | null>(
+  const safeEvaluate = useMemo<(rule: RuleName) => NGCEvaluatedNode | null>(
     () => (rule: string) => safeEvaluateHelper(rule, engine),
     [engine]
   )
 
-  const safeGetRule = useMemo<(rule: string) => NGCRuleNode | null>(
-    () => (rule: string) => {
-      let evaluation = null
+  const safeGetRule = useMemo<(rule: RuleName) => NGCRuleNode | null>(
+    () => (rule: RuleName) => {
       try {
-        evaluation = engine.getRule(rule)
+        return engine.getRule(rule)
       } catch (error) {
         console.error(error)
       }
-      return evaluation
+      return null
     },
     [engine]
   )

--- a/src/publicodes-state/providers/simulationProvider/useRules.ts
+++ b/src/publicodes-state/providers/simulationProvider/useRules.ts
@@ -57,8 +57,8 @@ export default function useRules({ engine }: { engine: Engine }): {
   // FIXME(@EmileRolley): refactoring not tested yet
   const everyMosaicChildWhoIsReallyInMosaic = useMemo<RuleName[]>(
     () =>
-      everyQuestions.filter((question: RuleName) =>
-        everyMosaicEntries.find(([mosaicName, mosaicRule]) => {
+      everyQuestions.filter((question: RuleName) => {
+        return everyMosaicEntries.find(([mosaicName, mosaicRule]) => {
           const mosaicNode = mosaicRule.rawNode?.mosaique
           if (!mosaicNode) {
             return false
@@ -70,7 +70,7 @@ export default function useRules({ engine }: { engine: Engine }): {
             question.includes(key)
           )
         })
-      ),
+      }),
     [everyQuestions, everyMosaicEntries]
   )
 

--- a/src/publicodes-state/providers/simulationProvider/useSituation.ts
+++ b/src/publicodes-state/providers/simulationProvider/useSituation.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
-import { safeGetSituation } from '../helpers/safeGetSituation'
-import { Engine, RuleName, Situation } from '../types'
+import { safeGetSituation } from '../../helpers/safeGetSituation'
+import { Engine, RuleName, Situation } from '../../types'
 
 type Props = {
   engine: Engine

--- a/src/publicodes-state/providers/simulationProvider/useSituation.ts
+++ b/src/publicodes-state/providers/simulationProvider/useSituation.ts
@@ -1,10 +1,10 @@
 import { useEffect, useState } from 'react'
-import { safeGetSituation } from '../../helpers/safeGetSituation'
-import { Engine, Situation } from '../../types'
+import { safeGetSituation } from '../helpers/safeGetSituation'
+import { Engine, RuleName, Situation } from '../types'
 
 type Props = {
   engine: Engine
-  everyRules: string[]
+  everyRules: RuleName[]
   defaultSituation?: Situation
   externalSituation: Situation
   updateExternalSituation: (situation: Situation) => void
@@ -22,7 +22,11 @@ export default function useSituation({
   defaultSituation = {},
   externalSituation,
   updateExternalSituation,
-}: Props) {
+}: Props): {
+  situation: Situation
+  updateSituation: (situation: Situation) => Promise<void>
+  initialized: boolean
+} {
   const [initialized, setInitialized] = useState(false)
   const [situation, setSituation] = useState(defaultSituation)
 

--- a/src/publicodes-state/simulationProvider/useCategories.ts
+++ b/src/publicodes-state/simulationProvider/useCategories.ts
@@ -1,0 +1,55 @@
+import { useMemo } from 'react'
+import { safeEvaluateHelper } from '../helpers/safeEvaluateHelper'
+import { Engine, NGCRuleNode } from '../types'
+
+type Props = {
+  engine: Engine
+  root: string
+  safeGetRule: (rule: string) => NGCRuleNode | null
+  order: string[] | null
+}
+
+export default function useCategories({
+  engine,
+  root,
+  safeGetRule,
+  order,
+}: Props) {
+  const categories = useMemo<string[]>(() => {
+    const sum = safeGetRule(root)?.rawNode?.formule?.somme
+    return order
+      ? // NOTE(@EmileRolley): what should be the wanted behavior if the order
+        // doesn't match the sum?
+        sum.sort((a: string, b: string) => order.indexOf(a) - order.indexOf(b))
+      : sum
+  }, [root, order, safeGetRule])
+
+  const subcategories = useMemo<Record<string, string[]>>(
+    () =>
+      categories.reduce((acc: object, category: string) => {
+        const categorySum = safeGetRule(category)?.rawNode?.formule?.somme
+
+        if (!categorySum || category === 'services sociétaux') {
+          return {
+            ...acc,
+            [category]: [],
+          }
+        }
+
+        const sortedSubCategory = categorySum
+          .map((rule: string) => category + ' . ' + rule)
+          .sort(
+            (a: string, b: string) =>
+              (safeEvaluateHelper(a, engine)?.nodeValue ?? 0) -
+              (safeEvaluateHelper(b, engine)?.nodeValue ?? 0)
+          )
+
+        return {
+          ...acc,
+          [category]: sortedSubCategory,
+        }
+      }, {}),
+    [categories, safeGetRule, engine]
+  )
+  return { categories, subcategories }
+}

--- a/src/publicodes-state/simulationProvider/useCategories.ts
+++ b/src/publicodes-state/simulationProvider/useCategories.ts
@@ -1,12 +1,12 @@
 import { useMemo } from 'react'
 import { safeEvaluateHelper } from '../helpers/safeEvaluateHelper'
-import { Engine, NGCRuleNode } from '../types'
+import { Engine, NGCRuleNode, RuleName } from '../types'
 
 type Props = {
   engine: Engine
-  root: string
+  root: RuleName
   safeGetRule: (rule: string) => NGCRuleNode | null
-  order: string[] | null
+  order: RuleName[] | null
 }
 
 export default function useCategories({
@@ -14,8 +14,11 @@ export default function useCategories({
   root,
   safeGetRule,
   order,
-}: Props) {
-  const categories = useMemo<string[]>(() => {
+}: Props): {
+  categories: RuleName[]
+  subcategories: Record<RuleName, RuleName[]>
+} {
+  const categories = useMemo<RuleName[]>(() => {
     const sum = safeGetRule(root)?.rawNode?.formule?.somme
     return order
       ? // NOTE(@EmileRolley): what should be the wanted behavior if the order
@@ -24,9 +27,9 @@ export default function useCategories({
       : sum
   }, [root, order, safeGetRule])
 
-  const subcategories = useMemo<Record<string, string[]>>(
+  const subcategories = useMemo<Record<RuleName, RuleName[]>>(
     () =>
-      categories.reduce((acc: object, category: string) => {
+      categories.reduce((acc: object, category: RuleName) => {
         const categorySum = safeGetRule(category)?.rawNode?.formule?.somme
 
         if (!categorySum || category === 'services sociétaux') {
@@ -37,9 +40,9 @@ export default function useCategories({
         }
 
         const sortedSubCategory = categorySum
-          .map((rule: string) => category + ' . ' + rule)
+          .map((rule: RuleName) => category + ' . ' + rule)
           .sort(
-            (a: string, b: string) =>
+            (a: RuleName, b: RuleName) =>
               (safeEvaluateHelper(a, engine)?.nodeValue ?? 0) -
               (safeEvaluateHelper(b, engine)?.nodeValue ?? 0)
           )

--- a/src/publicodes-state/types.d.ts
+++ b/src/publicodes-state/types.d.ts
@@ -113,3 +113,10 @@ type NGCRule = {
 }
 
 export type NGCRules = Record<string, NGCRule>
+
+export type NGCQuestionType =
+  | 'notQuestion'
+  | 'mosaic'
+  | 'choices'
+  | 'boolean'
+  | 'number'

--- a/src/publicodes-state/types.d.ts
+++ b/src/publicodes-state/types.d.ts
@@ -46,7 +46,7 @@ export type NGCRuleNode = RuleNode & {
 export type NGCRulesNodes = Record<string, NGCRuleNode>
 
 //TODO: complete explanation type
-export type NGCEvaluatedNode = EvaluatedNode & {
+export type NGCEvaluatedNode = EvaluatedNode<number> & {
   explanation: {
     ruleDisabledByItsParent: boolean
   }

--- a/src/publicodes-state/types.d.ts
+++ b/src/publicodes-state/types.d.ts
@@ -21,6 +21,8 @@ export type User = {
   hasSavedSimulation?: boolean
 }
 
+export type RuleName = string
+
 export type Rules = any
 
 export type Tutorials = Record<string, boolean>


### PR DESCRIPTION
> Closes https://github.com/incubateur-ademe/nosgestesclimat-site/issues/1315

# Code review - publicodes-state

J’avais en tête quelque chose du style [https://publi.codes/docs/api/react-ui](https://publi.codes/docs/api/react-ui) qui permettrait d’avoir un composant React `PublicodesForm` au quel on fournit un moteur et/ou un ensemble de règles et qui créer un formulaire à partir de celles-ci, mettant à jour une situation en fonction des réponses de l’utilisateur-ice. La gestion du state global de l’app serait alors laissée à l’utilisateur.ice — qui comprendrait dans le cas de NGC toute la gestion des *users, actions, etc…*

En l’état actuel, c’est un ensemble de hooks autour d’un state React. Ce qui est très bien pour isoler la logique métier, mais qui je pense est trop complexe et spécifique à NGC pour en faire une lib standalone.

## Remarques

### Contenu

🔴 La gestion de l’utilisateur est spécifique à NGC et ne devrait pas faire partie de `publicodes-state`.

🔴 A plusieurs endroits sont utilisés des noms de règle hardcodés du modèle NGC (ex. `bilan` et `services sociétaux`).

🟠 ❓ Entre `useDisposableEngine` et `useEngine` qui retourne deux moteurs différents, il est un peu compliqué de si retrouver et de savoir lequel utiliser. En particulier, pour le `pristineEngine` qui est utilisé à un seul endroit. Pourquoi ne pas utiliser `useDisposableEngine` avec une situation vide ?

🟠 Les actions sont pour l’instant assez spécifique à NGC donc je m’interroge sur la pertinence de garder `useActions` dans `publicodes-state`.

🟠 Un peu de doc pour dans chaque fichiers `index` ne serait pas de trop. De préférence au format [tsdoc](https://tsdoc.org/), ce qui permettrait de générer automatiquement une documentation de l’API facilement utilisable par d’autre dev.

### Tech/TS

🔴 Le fichier `types.d.ts` mélange tous les types, là où il serait préférable de séparer ce qui concerne la gestion des simulations/users des types relatifs au modèle Publicodes. 

🔴 ❓ De plus il y a une perte d’information par rapport au fichier [`publicodesUtils`](https://github.com/incubateur-ademe/nosgestesclimat-site/blob/3e1ecd00ef246bc0d936fcef40c159a9c447f327/source/components/publicodesUtils.tsx#L4), dans lequel j’avais fais l’effort de rédiger un minimum de documentation et pourquoi les types ne sont pas réutilisés ?

🔴  `any` aliases (ex. `Formule` et `Rules` dans `types.d.ts`)

🟠 Chaque function possède un type `Props` pour ses arguments ce qui est vraiment bien 👍. En revanche, très peu possède un type de retour, ce qui est dommage 😕

🟠 ❓ Pourquoi ne pas utiliser la format d’import `@/...`comme pour le reste de l’app ?

🟠 Plusieurs fonctions possèdent le même nom ce qui rend complique la manipulation du code, comme par exemple `useRules`.

🟡 Utiliser `root: string` n’est pas forcément très parlant, `rootRule: string` ou `root: RuleName` serait déjà plus clair je trouve.

### Général

🔴 Plusieurs casts passant par `unknown` 

🔴 Problème de l'utilisation de `useRule` dans le composant `ChoicesValue`. Par exemple, on obtient l'erreur suivante à la page `/simulateur/bilan`:
```
UnknownRule: 
[ Règle inconnue ]
➡️  Dans la règle "logement . chauffage collectif . false"
⚠️  La règle 'logement . chauffage collectif . false' n'existe pas
    NextJS 40
2027-ea3f8dac202ef1ed.js:4:1828
```
Le problème vient d'ici :

https://github.com/incubateur-ademe/nosgestesclimat-site-nextjs/blob/c676e90f7edefc3a6c5c474b0132177e69a8d984/src/components/misc/ChoicesValue.tsx#L9

🟠 L’utilisation de yarn 3 est forcée, cependant, le `yarn.lock` ne fonctionne plus une fois regénéré

🟠 ❓ Pourquoi utilise-t-on à la fois `axios` et `fetch` ?

🟠 Ce pattern apparait plusieurs fois dans le code, il pourrait être factorisé dans un fonction avec un nom explicite : 

https://github.com/incubateur-ademe/nosgestesclimat-site-nextjs/blob/c676e90f7edefc3a6c5c474b0132177e69a8d984/src/app/(layout-with-navigation)/stats/_components/content/IframeFigures.js#L60-L62

🟡 34 erreurs du type `error TS2786: 'XXXX' cannot be used as a JSX component`

🟡 ❓ Il y a-t-il une raison particulière pour forcer l’utilisation de Node 18 ?

🟡 Ce serait top de garder quelques `console.debug` pour pouvoir savoir combien de règles sont chargées, quand, le temps que ça a pris etc...

## Questions

### Tech/TS

1. Par rapport aux types relatifs au modèle Publicodes, il faudrait arriver à séparer ceux qui sont propres à NGC (et qui sont préfixé par NGC) de ceux génériques, utilisable par n’importe quel modèle Publicodes. Quel serait la manière de faire la plus appropriée ?
2. Est-ce que l’on a envie d’utiliser des composant `Trans` dans `publicodes-state` ? Je ne pense pas, et en tel cas, le [`useForm/index.ts`](https://github.com/incubateur-ademe/nosgestesclimat-site-nextjs/blob/95b1c6872a8930f49bb0e03b35154ba13f83b036/src/publicodes-state/formProvider/index.tsx) n’a peut-être pas sa place dans `publicodes-state`.
3. Est-ce qu’il ne faudrait pas setup eslint et prettier dans la CI pour s’assurer de l’uniformité de la codebase ?

## Changelog

- New type: `NGCQuestionType` (+ use `switch` statement instead of `if-then-else`)