### PR TITLE
Retire le bandeau de localisation sur la page profil en mode iframe

### DIFF
--- a/src/app/(layout-with-navigation)/(simulation)/profil/_components/ProfilPageContent.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/profil/_components/ProfilPageContent.tsx
@@ -1,10 +1,12 @@
 'use client'
 
 import Trans from '@/components/translation/Trans'
+import { IframeOptionsContext } from '@/contexts/IframeOptionsContext'
 import { useUser } from '@/publicodes-state'
 import { SuppportedRegions } from '@/types/international'
 import { Simulation } from '@/types/simulation'
 import { capitaliseString } from '@/utils/capitaliseString'
+import { useContext } from 'react'
 import HasSimulationBanner from './HasSimulationBanner'
 import NoSimulationBanner from './NoSimulationBanner'
 import SimulationList from './SimulationList'
@@ -16,6 +18,8 @@ type Props = {
 }
 export default function ProfilPageContent({ supportedRegions }: Props) {
   const { simulations, currentSimulationId } = useUser()
+
+  const { isIframe } = useContext(IframeOptionsContext)
 
   const currentSimulation = (simulations as Simulation[]).find(
     (simulation: Simulation) => simulation.id === currentSimulationId
@@ -38,7 +42,7 @@ export default function ProfilPageContent({ supportedRegions }: Props) {
 
       <HasSimulationBanner />
 
-      <Localisation supportedRegions={supportedRegions} />
+      {!isIframe && <Localisation supportedRegions={supportedRegions} />}
 
       <SimulationAnswerList />
 


### PR DESCRIPTION
Corrige le bug remonté par Clément quand on cherche à accéder à la page Profil en mode iframe.