### PR TITLE
Hotfix: débloquer le bouton suivant pour les questions non applicables (lié à issue 2111)

### DIFF
--- a/src/publicodes-state/useRule/useValue.ts
+++ b/src/publicodes-state/useRule/useValue.ts
@@ -63,6 +63,7 @@ export default function useValue({
   const setDefaultAsValue = async (foldedStep?: string): Promise<void> => {
     if (foldedStep) addFoldedStep(foldedStep)
 
+    console.log(value)
     let situationToUpdate = {}
     if (type?.includes('mosaic')) {
       situationToUpdate = questionsOfMosaic.reduce(
@@ -106,6 +107,9 @@ const checkValueValidity = ({
 }): NodeValue => {
   switch (type) {
     case 'choices':
+      if (!value) {
+        return null
+      }
       return value.startsWith("'") ? value : `'${value}'`
     case 'boolean':
       return value === null || value === false || value === 'non' // Model shenanigans

--- a/src/publicodes-state/useRule/useValue.ts
+++ b/src/publicodes-state/useRule/useValue.ts
@@ -63,7 +63,6 @@ export default function useValue({
   const setDefaultAsValue = async (foldedStep?: string): Promise<void> => {
     if (foldedStep) addFoldedStep(foldedStep)
 
-    console.log(value)
     let situationToUpdate = {}
     if (type?.includes('mosaic')) {
       situationToUpdate = questionsOfMosaic.reduce(


### PR DESCRIPTION
Les erreurs s'afficheront toujours dans la console mais au moins le bouton suivant ne sera plus bloqué