### PR TITLE
Fix iframe simulation (NGC-76)

### DIFF
--- a/public/iframeSimulation.js
+++ b/public/iframeSimulation.js
@@ -10,7 +10,7 @@ const hostname = srcURL.origin || 'https://nosgestesclimat.fr'
 const possibleOptions = [
   { key: 'shareData', legacy: 'partagedatafinsimulation' },
   { key: 'lang' },
-  { key: 'localisation' },
+  { key: 'region' },
   { key: 'onlySimulation' },
   { key: 'pr' },
 ]

--- a/src/app/(iframe)/demo-iframeSimulation/page.tsx
+++ b/src/app/(iframe)/demo-iframeSimulation/page.tsx
@@ -19,7 +19,7 @@ export default function DemoIframePage() {
           id="nosgestesclimat"
           src="/iframeSimulation.js"
           data-only-simulation="true"
-          data-region="CH"
+          data-localisation="CH"
           data-pr="1872"
           data-share-data="true"
         />

--- a/src/app/(iframe)/demo-iframeSimulation/page.tsx
+++ b/src/app/(iframe)/demo-iframeSimulation/page.tsx
@@ -21,7 +21,6 @@ export default function DemoIframePage() {
           data-only-simulation="true"
           data-region="CH"
           data-pr="1872"
-          data-share-data="true"
         />
       </main>
     </div>

--- a/src/app/(iframe)/demo-iframeSimulation/page.tsx
+++ b/src/app/(iframe)/demo-iframeSimulation/page.tsx
@@ -19,7 +19,7 @@ export default function DemoIframePage() {
           id="nosgestesclimat"
           src="/iframeSimulation.js"
           data-only-simulation="true"
-          data-localisation="CH"
+          data-region="CH"
           data-pr="1872"
           data-share-data="true"
         />

--- a/src/app/(layout-with-navigation)/(simulation)/profil/_components/ProfilPageContent.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/profil/_components/ProfilPageContent.tsx
@@ -1,12 +1,11 @@
 'use client'
 
 import Trans from '@/components/translation/Trans'
-import { IframeOptionsContext } from '@/contexts/IframeOptionsContext'
+import { useIframe } from '@/hooks/useIframe'
 import { useUser } from '@/publicodes-state'
 import { SuppportedRegions } from '@/types/international'
 import { Simulation } from '@/types/simulation'
 import { capitaliseString } from '@/utils/capitaliseString'
-import { useContext } from 'react'
 import HasSimulationBanner from './HasSimulationBanner'
 import NoSimulationBanner from './NoSimulationBanner'
 import SimulationList from './SimulationList'
@@ -19,7 +18,7 @@ type Props = {
 export default function ProfilPageContent({ supportedRegions }: Props) {
   const { simulations, currentSimulationId } = useUser()
 
-  const { isIframe } = useContext(IframeOptionsContext)
+  const { iframeRegion } = useIframe()
 
   const currentSimulation = (simulations as Simulation[]).find(
     (simulation: Simulation) => simulation.id === currentSimulationId
@@ -42,7 +41,7 @@ export default function ProfilPageContent({ supportedRegions }: Props) {
 
       <HasSimulationBanner />
 
-      {!isIframe && <Localisation supportedRegions={supportedRegions} />}
+      {!iframeRegion && <Localisation supportedRegions={supportedRegions} />}
 
       <SimulationAnswerList />
 

--- a/src/app/(layout-with-navigation)/(simulation)/profil/_components/localisation/Localisation.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/profil/_components/localisation/Localisation.tsx
@@ -23,7 +23,7 @@ export default function Localisation({
 
   const locale = useLocale()
 
-  const { user, updateRegion } = useUser()
+  const { user, updateRegion, tutorials, showTutorial } = useUser()
   const { region, initialRegion } = user || {}
 
   const isRegionSupported = Object.keys(supportedRegions)?.some(
@@ -68,6 +68,8 @@ export default function Localisation({
                     updateRegion(
                       initialRegion as { code: string; name: string }
                     )
+                    tutorials.localisationBanner &&
+                      showTutorial('localisationBanner')
                   }}>
                   <Trans>Revenir à ma région par défaut </Trans>{' '}
                   <span aria-label={initialRegion.name}>

--- a/src/app/(layout-with-navigation)/(simulation)/profil/_components/localisation/Localisation.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/profil/_components/localisation/Localisation.tsx
@@ -68,8 +68,9 @@ export default function Localisation({
                     updateRegion(
                       initialRegion as { code: string; name: string }
                     )
-                    tutorials.localisationBanner &&
+                    if (tutorials.localisationBanner) {
                       showTutorial('localisationBanner')
+                    }
                   }}>
                   <Trans>Revenir à ma région par défaut </Trans>{' '}
                   <span aria-label={initialRegion.name}>

--- a/src/app/(layout-with-navigation)/(simulation)/profil/_components/localisation/RegionSelector.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/profil/_components/localisation/RegionSelector.tsx
@@ -63,7 +63,9 @@ export default function RegionSelector({
               code,
               name: supportedRegions[code][locale]?.nom as unknown as string,
             })
-            tutorials.localisationBanner && showTutorial('localisationBanner')
+            if (tutorials.localisationBanner) {
+              showTutorial('localisationBanner')
+            }
           }}
           selectedRegionCode={region?.code}
           className={isFetching ? 'pointer-events-none opacity-60' : ''}

--- a/src/app/(layout-with-navigation)/(simulation)/profil/_components/localisation/RegionSelector.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/profil/_components/localisation/RegionSelector.tsx
@@ -27,7 +27,7 @@ export default function RegionSelector({
 
   const numberOfRegions = Object.entries(orderedSupportedRegions).length
 
-  const { updateRegion, user } = useUser()
+  const { updateRegion, user, tutorials, showTutorial } = useUser()
 
   // NOTE(@EmileRolley): how could this be undefined? This doesn't match the type annotations
   const { region } = user ?? {}
@@ -63,6 +63,7 @@ export default function RegionSelector({
               code,
               name: supportedRegions[code][locale]?.nom as unknown as string,
             })
+            tutorials.localisationBanner && showTutorial('localisationBanner')
           }}
           selectedRegionCode={region?.code}
           className={isFetching ? 'pointer-events-none opacity-60' : ''}

--- a/src/app/(layout-with-navigation)/(simulation)/simulateur/[root]/_components/Faq.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/simulateur/[root]/_components/Faq.tsx
@@ -6,9 +6,9 @@ import Trans from '@/components/translation/Trans'
 import { useIframe } from '@/hooks/useIframe'
 
 export default function Faq() {
-  const { iframeOnlySimulation } = useIframe()
+  const { isIframeOnlySimulation } = useIframe()
 
-  if (iframeOnlySimulation) return null
+  if (isIframeOnlySimulation) return null
 
   return (
     <div className="mx-auto mb-4 rounded-lg bg-primaryLight p-4 text-center">

--- a/src/app/(layout-with-navigation)/(simulation)/simulateur/[root]/_components/Faq.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/simulateur/[root]/_components/Faq.tsx
@@ -1,15 +1,23 @@
+'use client'
+
 import Link from '@/components/Link'
 import Trans from '@/components/translation/Trans'
 
+import { useIframe } from '@/hooks/useIframe'
+
 export default function Faq() {
+  const { iframeOnlySimulation } = useIframe()
+
   return (
-    <div className="mx-auto mb-4 rounded-lg bg-primaryLight p-4 text-center">
-      <p>
-        <Trans>Une question, un problème ?</Trans>
-      </p>
-      <Link href="/questions-frequentes">
-        <Trans>Découvrez la FAQ !</Trans>
-      </Link>
-    </div>
+    !iframeOnlySimulation && (
+      <div className="mx-auto mb-4 rounded-lg bg-primaryLight p-4 text-center">
+        <p>
+          <Trans>Une question, un problème ?</Trans>
+        </p>
+        <Link href="/questions-frequentes">
+          <Trans>Découvrez la FAQ !</Trans>
+        </Link>
+      </div>
+    )
   )
 }

--- a/src/app/(layout-with-navigation)/(simulation)/simulateur/[root]/_components/Faq.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/simulateur/[root]/_components/Faq.tsx
@@ -8,16 +8,16 @@ import { useIframe } from '@/hooks/useIframe'
 export default function Faq() {
   const { iframeOnlySimulation } = useIframe()
 
+  if (iframeOnlySimulation) return null
+
   return (
-    !iframeOnlySimulation && (
-      <div className="mx-auto mb-4 rounded-lg bg-primaryLight p-4 text-center">
-        <p>
-          <Trans>Une question, un problème ?</Trans>
-        </p>
-        <Link href="/questions-frequentes">
-          <Trans>Découvrez la FAQ !</Trans>
-        </Link>
-      </div>
-    )
+    <div className="mx-auto mb-4 rounded-lg bg-primaryLight p-4 text-center">
+      <p>
+        <Trans>Une question, un problème ?</Trans>
+      </p>
+      <Link href="/questions-frequentes">
+        <Trans>Découvrez la FAQ !</Trans>
+      </Link>
+    </div>
   )
 }

--- a/src/app/(layout-with-navigation)/(simulation)/simulateur/[root]/_components/simulateur/Charts.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/simulateur/[root]/_components/simulateur/Charts.tsx
@@ -8,7 +8,7 @@ export default function Charts() {
   const [isBarChartVisible, setIsBarChartVisible] = useState(false)
   if (!currentCategory) return
   return (
-    <div className="mb-8 flex flex-col">
+    <div className="flex flex-col pb-24">
       <InlineChart />
       <button
         className="mx-auto"

--- a/src/app/(layout-with-navigation)/_components/Navigation.tsx
+++ b/src/app/(layout-with-navigation)/_components/Navigation.tsx
@@ -10,6 +10,7 @@ import Trans from '@/components/translation/Trans'
 import { useClientTranslation } from '@/hooks/useClientTranslation'
 import { useDebug } from '@/hooks/useDebug'
 import { useGetPRNumber } from '@/hooks/useGetPRNumber'
+import { useIframe } from '@/hooks/useIframe'
 import { useUser } from '@/publicodes-state'
 import { capitaliseString } from '@/utils/capitaliseString'
 import Image from 'next/image'
@@ -55,6 +56,8 @@ export default function Navigation() {
   const persona: string | undefined = getCurrentSimulation()?.persona
 
   const { PRNumber, clearPRNumber } = useGetPRNumber()
+
+  const { iframeRegion } = useIframe()
 
   return (
     <nav
@@ -128,7 +131,7 @@ export default function Navigation() {
             </NavLink>
           )}
 
-          {PRNumber && (
+          {PRNumber && !iframeRegion && (
             <NavLink
               href={
                 'https://github.com/datagir/nosgestesclimat/pull/' + PRNumber

--- a/src/app/_components/Providers.tsx
+++ b/src/app/_components/Providers.tsx
@@ -4,6 +4,7 @@ import { IframeOptionsProvider } from '@/contexts/IframeOptionsContext'
 import { UserProvider } from '@/publicodes-state'
 import { PropsWithChildren } from 'react'
 import { IsClientCtxProvider } from './IsClientCtxProvider'
+import CheckFixedRegion from './providers/CheckFixedRegion'
 import { IframeResizer } from './providers/IframeResizer'
 import PageViewTracker from './providers/PageViewTracker'
 import QueryClientProviderWrapper from './providers/QueryClientProviderWrapper'
@@ -25,6 +26,7 @@ export default function Providers({
                 initialRegion={region}
                 storageKey="nosgestesclimat::v3">
                 <SimulationFromUrlLoader />
+                <CheckFixedRegion />
                 <IsClientCtxProvider>{children}</IsClientCtxProvider>
               </UserProvider>
             </PageViewTracker>

--- a/src/app/_components/providers/CheckFixedRegion.tsx
+++ b/src/app/_components/providers/CheckFixedRegion.tsx
@@ -8,13 +8,12 @@ export default function CheckFixedRegion() {
   const { user, updateRegion } = useUser()
 
   useEffect(() => {
-    if (fixedRegionCode && fixedRegionCode !== user?.region?.code) {
-      const region = countries.find(
-        (country) => country.code === fixedRegionCode
-      )
-      if (region) {
-        updateRegion(region)
-      }
+    // Do nothing if region is the same as the user's
+    if (!fixedRegionCode && fixedRegionCode === user?.region?.code) return
+
+    const region = countries.find((country) => country.code === fixedRegionCode)
+    if (region) {
+      updateRegion(region)
     }
   }, [user, fixedRegionCode, updateRegion])
 

--- a/src/app/_components/providers/CheckFixedRegion.tsx
+++ b/src/app/_components/providers/CheckFixedRegion.tsx
@@ -1,0 +1,22 @@
+import countries from '@/app/api/geolocation/countries.json'
+import { useUser } from '@/publicodes-state'
+import { useSearchParams } from 'next/navigation'
+import { useEffect } from 'react'
+export default function CheckFixedRegion() {
+  const fixedRegionCode = useSearchParams().get('region')
+
+  const { user, updateRegion } = useUser()
+
+  useEffect(() => {
+    if (fixedRegionCode && fixedRegionCode !== user?.region?.code) {
+      const region = countries.find(
+        (country) => country.code === fixedRegionCode
+      )
+      if (region) {
+        updateRegion(region)
+      }
+    }
+  }, [user, fixedRegionCode, updateRegion])
+
+  return null
+}

--- a/src/app/documentation/_components/DocumentationContent.tsx
+++ b/src/app/documentation/_components/DocumentationContent.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Link from '@/components/Link'
+import LocalisationBanner from '@/components/translation/LocalisationBanner'
 import Markdown from '@/design-system/utils/Markdown'
 import { useClientTranslation } from '@/hooks/useClientTranslation'
 import { useLocale } from '@/hooks/useLocale'
@@ -63,17 +64,20 @@ export default function DocumentationContent({
   if (!engine) return
 
   return (
-    <RulePage
-      language={i18n.language as 'fr' | 'en'}
-      rulePath={(path as string) ?? ''}
-      engine={engine as Engine}
-      documentationPath={documentationPath}
-      renderers={{
-        Head,
-        Link: ({ children, to }) => <Link href={to || ''}>{children}</Link>,
-        Text: ({ children }) => <Markdown>{children}</Markdown>,
-        References: References as any,
-      }}
-    />
+    <>
+      <LocalisationBanner supportedRegions={supportedRegions} />
+      <RulePage
+        language={i18n.language as 'fr' | 'en'}
+        rulePath={(path as string) ?? ''}
+        engine={engine as Engine}
+        documentationPath={documentationPath}
+        renderers={{
+          Head,
+          Link: ({ children, to }) => <Link href={to || ''}>{children}</Link>,
+          Text: ({ children }) => <Markdown>{children}</Markdown>,
+          References: References as any,
+        }}
+      />
+    </>
   )
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -376,8 +376,8 @@ blockquote {
 /*
   Iframe
   */
-.iframe header,
-.iframe footer {
+.iframeOnlySimulation header,
+.iframeOnlySimulation footer {
   display: none;
 }
 
@@ -385,12 +385,12 @@ blockquote {
   Accessibility
 */
 .sr-only {
-	position: absolute;
-	width: 1px;
-	height: 1px;
-	padding: 0;
-	margin: -1px;
-	overflow: hidden;
-	clip: rect(0,0,0,0);
-	border: 0;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
 }

--- a/src/components/iframe/IframeDataShareModal.tsx
+++ b/src/components/iframe/IframeDataShareModal.tsx
@@ -57,7 +57,7 @@ export default function IframeDataShareModal() {
   if (
     !iframeOptions.isIframe ||
     !document.referrer ||
-    !iframeOptions?.iframeShareData
+    !iframeOptions?.isIframeShareData
   ) {
     return null
   }

--- a/src/components/misc/Logo.tsx
+++ b/src/components/misc/Logo.tsx
@@ -11,7 +11,7 @@ export default function Logo({
   size?: 'xs' | 'sm' | 'lg'
   className?: string
 }) {
-  const { isIframe } = useIframe()
+  const { iframeOnlySimulation } = useIframe()
 
   const classnames = {
     xs: {
@@ -40,7 +40,7 @@ export default function Logo({
         className={`mx-auto my-1 flex items-center justify-center no-underline md:my-4 lg:mx-auto lg:my-4 ${
           // @bjlaa : this is a hack to prevent the logo from being clickable in the iframe
           // not a recommended method a11y-wise, but in this case it's a good fit
-          isIframe ? 'pointer-events-none' : ''
+          iframeOnlySimulation ? 'pointer-events-none' : ''
         }`}>
         <Image
           src="/images/misc/petit-logo@3x.png"

--- a/src/components/misc/Logo.tsx
+++ b/src/components/misc/Logo.tsx
@@ -11,7 +11,7 @@ export default function Logo({
   size?: 'xs' | 'sm' | 'lg'
   className?: string
 }) {
-  const { iframeOnlySimulation } = useIframe()
+  const { isIframeOnlySimulation } = useIframe()
 
   const classnames = {
     xs: {
@@ -40,7 +40,7 @@ export default function Logo({
         className={`mx-auto my-1 flex items-center justify-center no-underline md:my-4 lg:mx-auto lg:my-4 ${
           // @bjlaa : this is a hack to prevent the logo from being clickable in the iframe
           // not a recommended method a11y-wise, but in this case it's a good fit
-          iframeOnlySimulation ? 'pointer-events-none' : ''
+          isIframeOnlySimulation ? 'pointer-events-none' : ''
         }`}>
         <Image
           src="/images/misc/petit-logo@3x.png"

--- a/src/components/misc/Logo.tsx
+++ b/src/components/misc/Logo.tsx
@@ -1,8 +1,7 @@
 'use client'
 
-import { IframeOptionsContext } from '@/contexts/IframeOptionsContext'
+import { useIframe } from '@/hooks/useIframe'
 import Image from 'next/image'
-import { useContext } from 'react'
 import Link from '../Link'
 
 export default function Logo({
@@ -12,7 +11,7 @@ export default function Logo({
   size?: 'xs' | 'sm' | 'lg'
   className?: string
 }) {
-  const { isIframe } = useContext(IframeOptionsContext)
+  const { isIframe } = useIframe()
 
   const classnames = {
     xs: {

--- a/src/components/translation/LocalisationBanner.tsx
+++ b/src/components/translation/LocalisationBanner.tsx
@@ -41,9 +41,9 @@ export default function LocalisationBanner({ supportedRegions }: Props) {
       regionParams?.[currentLocale]?.['nom']
     : countryName
 
-  if (tutorials.localisationBanner) return
+  if (tutorials.localisationBanner) return null
 
-  if (code === defaultModelRegionCode) return
+  if (code === defaultModelRegionCode) return null
 
   return (
     <Card

--- a/src/components/translation/LocalisationBanner.tsx
+++ b/src/components/translation/LocalisationBanner.tsx
@@ -6,6 +6,7 @@ import { getMatomoEventChangeRegion } from '@/constants/matomo'
 import { defaultModelRegionCode } from '@/constants/translation'
 import Button from '@/design-system/inputs/Button'
 import Card from '@/design-system/layout/Card'
+import { useIframe } from '@/hooks/useIframe'
 import { useLocale } from '@/hooks/useLocale'
 import { useUser } from '@/publicodes-state'
 import { SuppportedRegions } from '@/types/international'
@@ -22,6 +23,10 @@ export default function LocalisationBanner({ supportedRegions }: Props) {
   const currentLocale = useLocale() as string
 
   const code = user?.region?.code
+
+  const { iframeRegion } = useIframe()
+
+  if (iframeRegion) return null
 
   if (!supportedRegions) return null
 
@@ -43,8 +48,7 @@ export default function LocalisationBanner({ supportedRegions }: Props) {
   return (
     <Card
       className="mx-auto mb-8 w-[32rem] max-w-full flex-row"
-      style={{ backgroundColor: '#fff8d3' }}
-    >
+      style={{ backgroundColor: '#fff8d3' }}>
       <div className="flex gap-8">
         <div className="flex w-8 items-center text-4xl">📍</div>
         <div className="flex-1">
@@ -112,8 +116,7 @@ export default function LocalisationBanner({ supportedRegions }: Props) {
               hideTutorial('localisationBanner')
 
               trackEvent(getMatomoEventChangeRegion(code))
-            }}
-          >
+            }}>
             <Trans>J'ai compris</Trans>
           </Button>
         </div>

--- a/src/contexts/IframeOptionsContext.tsx
+++ b/src/contexts/IframeOptionsContext.tsx
@@ -63,8 +63,7 @@ export const IframeOptionsProvider = ({ children }: PropsWithChildren) => {
 
   if (isIframeOnlySimulation) {
     // Add class to body that hides the header and the footer
-    // @Clemog: Je ne comprends pas ce qui est fait ici ? Pourquoi on a une condition supplémentaire avec isIframe ? Que met-on à jour ?
-    document.body.classList.add(isIframe ? 'iframe' : '')
+    document.body.classList.add('iframeOnlySimulation')
   }
 
   const finalValue = {

--- a/src/contexts/IframeOptionsContext.tsx
+++ b/src/contexts/IframeOptionsContext.tsx
@@ -63,6 +63,7 @@ export const IframeOptionsProvider = ({ children }: PropsWithChildren) => {
 
   if (iframeOnlySimulation) {
     // Add class to body that hides the header and the footer
+    // @Clemog: Je ne comprends pas ce qui est fait ici ? Pourquoi on a une condition supplémentaire avec isIframe ? Que met-on à jour ?
     document.body.classList.add(isIframe ? 'iframe' : '')
   }
 

--- a/src/contexts/IframeOptionsContext.tsx
+++ b/src/contexts/IframeOptionsContext.tsx
@@ -8,9 +8,9 @@ import { getIsIframe } from '../utils/getIsIframe'
 
 export const IframeOptionsContext = createContext<{
   isIframe?: boolean
-  iframeShareData?: string | null
+  isIframeShareData?: boolean
   iframeRegion?: string | null
-  iframeOnlySimulation?: boolean
+  isIframeOnlySimulation?: boolean
 }>({})
 
 const nullDecode = (string: string) =>
@@ -55,13 +55,13 @@ export const IframeOptionsProvider = ({ children }: PropsWithChildren) => {
     ])
   )
 
-  const iframeShareData = urlParams.get('shareData')
+  const isIframeShareData = Boolean(urlParams.get('shareData'))
 
   const iframeRegion = urlParams.get('region')
 
-  const iframeOnlySimulation = Boolean(urlParams.get('onlySimulation'))
+  const isIframeOnlySimulation = Boolean(urlParams.get('onlySimulation'))
 
-  if (iframeOnlySimulation) {
+  if (isIframeOnlySimulation) {
     // Add class to body that hides the header and the footer
     // @Clemog: Je ne comprends pas ce qui est fait ici ? Pourquoi on a une condition supplémentaire avec isIframe ? Que met-on à jour ?
     document.body.classList.add(isIframe ? 'iframe' : '')
@@ -70,9 +70,9 @@ export const IframeOptionsProvider = ({ children }: PropsWithChildren) => {
   const finalValue = {
     ...iframeIntegratorOptions,
     isIframe,
-    iframeShareData,
+    isIframeShareData,
     iframeRegion,
-    iframeOnlySimulation,
+    isIframeOnlySimulation,
   }
 
   return (

--- a/src/contexts/IframeOptionsContext.tsx
+++ b/src/contexts/IframeOptionsContext.tsx
@@ -9,7 +9,7 @@ import { getIsIframe } from '../utils/getIsIframe'
 export const IframeOptionsContext = createContext<{
   isIframe?: boolean
   iframeShareData?: string | null
-  iframeLocalisation?: string | null
+  iframeRegion?: string | null
   iframeOnlySimulation?: boolean
 }>({})
 
@@ -57,7 +57,7 @@ export const IframeOptionsProvider = ({ children }: PropsWithChildren) => {
 
   const iframeShareData = urlParams.get('shareData')
 
-  const iframeLocalisation = urlParams.get('localisation')
+  const iframeRegion = urlParams.get('region')
 
   const iframeOnlySimulation = Boolean(urlParams.get('onlySimulation'))
 
@@ -70,7 +70,7 @@ export const IframeOptionsProvider = ({ children }: PropsWithChildren) => {
     ...iframeIntegratorOptions,
     isIframe,
     iframeShareData,
-    iframeLocalisation,
+    iframeRegion,
     iframeOnlySimulation,
   }
 


### PR DESCRIPTION
Fix https://github.com/incubateur-ademe/nosgestesclimat-site/issues/1404

@florianpanchout @bjlaa, j'ai fait un commentaire dans le code car je ne comprends pas comment est géré la déésactivation du footer pour l'iframe avec le paramètre "onlySimulation" ?

J'ai également une incompréhension autour du composant `LocalisationBanner` qui est passé à `SimulationProvider` ?

Le comportement attendu (un peu hors de l'issue) pour cette bannière devrait être (ping @jeannelf): -> Normalement c'est fixé dans cette PR

- Affichage à chaque modification de la région
- affichage sur les pages profil, agir, simulation, documentation