### PR TITLE
Fix: issues displayed in /model

### DIFF
--- a/src/app/(layout-with-navigation)/(pages-statiques)/modele/_components/modele/ModeleIssuePreviews.tsx
+++ b/src/app/(layout-with-navigation)/(pages-statiques)/modele/_components/modele/ModeleIssuePreviews.tsx
@@ -4,7 +4,7 @@ import Card from '@/design-system/layout/Card'
 import Markdown from '@/design-system/utils/Markdown'
 import axios from 'axios'
 
-const labelString = ['exposé'].join(',')
+const labelString = ['🖼 exposé'].join(',')
 
 type IssueType = {
   body: string


### PR DESCRIPTION
Mini PR pour fix l'affichage des issues dans https://nosgestesclimat.fr/modele

Repéré en travaillant sur les attributs site inutiles présent dans le modèle, dont "exposé" faisait partie mais qui n'est pas lié à celui corrigé ici