### PR TITLE
Release 1.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,5 +144,5 @@
     "yaml-loader": "^0.8.0",
     "yargs": "^17.7.2"
   },
-  "packageManager": "yarn@3.6.4"
+  "packageManager": "yarn@1.22.19"
 }

--- a/public/iframe.js
+++ b/public/iframe.js
@@ -5,7 +5,7 @@ const script =
 const integratorUrl = encodeURIComponent(window.location.href.toString())
 
 const srcURL = new URL(script.src)
-const hostname = srcURL.hostname || 'nosgestesclimat.fr'
+const hostname = srcURL.origin || 'nosgestesclimat.fr'
 
 const possibleOptions = [
   { key: 'shareData', legacy: 'partagedatafinsimulation' },
@@ -18,7 +18,7 @@ const optionFragments = possibleOptions.map(({ key, legacy }) => {
   return value != null ? `&${key}=${value}` : ''
 })
 
-const src = `https://${hostname}/?iframe&integratorUrl=${integratorUrl}${optionFragments.join(
+const src = `${hostname}/?iframe&integratorUrl=${integratorUrl}${optionFragments.join(
   ''
 )}`
 

--- a/src/app/(layout-with-navigation)/(simulation)/actions/plus/_components/ActionPlusList.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/actions/plus/_components/ActionPlusList.tsx
@@ -3,7 +3,7 @@
 import Link from '@/components/Link'
 import Card from '@/design-system/layout/Card'
 import { getRuleTitle } from '@/helpers/publicodes/getRuleTitle'
-import { useGetPRNumber } from '@/hooks/useGetPRNumber'
+import { usePRNumber } from '@/hooks/usePRNumber'
 import { useTempEngine } from '@/publicodes-state'
 import { NGCRule, NGCRules } from '@/publicodes-state/types'
 import { utils } from 'publicodes'
@@ -12,7 +12,7 @@ import { useFetchDocumentation } from '../../_hooks/useFetchDocumentation'
 export default function ActionPlusList() {
   const { rules } = useTempEngine()
 
-  const { PRNumber } = useGetPRNumber()
+  const { PRNumber } = usePRNumber()
 
   const { data: documentation } = useFetchDocumentation(PRNumber)
 

--- a/src/app/(layout-with-navigation)/_components/Navigation.tsx
+++ b/src/app/(layout-with-navigation)/_components/Navigation.tsx
@@ -9,13 +9,11 @@ import Trans from '@/components/translation/Trans'
 
 import { useClientTranslation } from '@/hooks/useClientTranslation'
 import { useDebug } from '@/hooks/useDebug'
-import { useGetPRNumber } from '@/hooks/useGetPRNumber'
-import { useIframe } from '@/hooks/useIframe'
 import { useUser } from '@/publicodes-state'
 import { capitaliseString } from '@/utils/capitaliseString'
 import Image from 'next/image'
-import { usePathname, useRouter } from 'next/navigation'
 import NavLink from './navigation/NavLink'
+import PRIndicator from './navigation/PRIndicator'
 
 const ActionsInteractiveIcon = ({ className = '' }) => {
   const actionChoices = {}
@@ -43,11 +41,7 @@ export const conferenceImg = openmojiURL('conference')
 export default function Navigation() {
   const { t } = useClientTranslation()
 
-  const router = useRouter()
-
   const isDebug = useDebug()
-
-  const pathname = usePathname()
 
   const enquete = ''
 
@@ -55,20 +49,11 @@ export default function Navigation() {
 
   const persona: string | undefined = getCurrentSimulation()?.persona
 
-  const { PRNumber, clearPRNumber } = useGetPRNumber()
-
-  const { iframeRegion } = useIframe()
-
   return (
     <nav
       id="mainNavigation"
       className="z-50 my-2 flex h-auto flex-col justify-center pb-8 outline-none lg:sticky lg:top-0 lg:my-4 lg:w-[14rem] lg:shrink-0 lg:justify-start lg:overflow-hidden lg:border-0 lg:border-r-[1px] lg:border-solid lg:border-grey-200">
       <Logo size="sm" className="hidden lg:block" />
-      {isDebug ? (
-        <div className="mx-auto hidden rounded-lg bg-red-600 px-4 py-2 text-center font-bold uppercase text-white lg:block">
-          Debug
-        </div>
-      ) : null}
       <div className="z-100 fixed bottom-0 left-0 m-0 w-screen border-0 border-t-[1px] border-solid border-grey-200 lg:static lg:z-auto lg:mt-4 lg:w-auto lg:border-none">
         <ul className="m-0 flex h-20 w-full list-none justify-between bg-white py-1 shadow-md sm:px-4 lg:h-auto lg:flex-col lg:justify-start lg:gap-1 lg:bg-none lg:py-2 lg:shadow-none">
           <NavLink
@@ -130,42 +115,12 @@ export default function Navigation() {
               </span>
             </NavLink>
           )}
-
-          {PRNumber && !iframeRegion && (
-            <NavLink
-              href={
-                'https://github.com/datagir/nosgestesclimat/pull/' + PRNumber
-              }>
-              <Image
-                src={openmojiURL('github')}
-                alt=""
-                className="w-8 lg:mr-4"
-                aria-hidden="true"
-                width="20"
-                height="20"
-              />
-              <span className="font-base text-sm text-primaryDark md:text-lg">
-                #{PRNumber}
-              </span>
-
-              <button
-                onClick={(event) => {
-                  event.stopPropagation()
-
-                  clearPRNumber()
-
-                  router.push(pathname)
-                }}>
-                <Image
-                  className="w-6"
-                  src="/images/misc/close-plain.svg"
-                  alt=""
-                  width="1"
-                  height="1"
-                />
-              </button>
-            </NavLink>
-          )}
+          <PRIndicator />
+          {isDebug ? (
+            <div className="mx-auto hidden rounded-lg bg-red-600 px-4 py-2 text-center font-bold uppercase text-white lg:block">
+              Debug
+            </div>
+          ) : null}
         </ul>
       </div>
     </nav>

--- a/src/app/(layout-with-navigation)/_components/navigation/PRIndicator.tsx
+++ b/src/app/(layout-with-navigation)/_components/navigation/PRIndicator.tsx
@@ -1,0 +1,48 @@
+import Link from '@/components/Link'
+import { useIframe } from '@/hooks/useIframe'
+import { usePRNumber } from '@/hooks/usePRNumber'
+import Image from 'next/image'
+import { useRouter } from 'next/navigation'
+
+export default function PRIndicator() {
+  const router = useRouter()
+
+  const { PRNumber, clearPRNumber } = usePRNumber()
+
+  const { iframeRegion } = useIframe()
+
+  if (!PRNumber || iframeRegion) return null
+
+  return (
+    <div className="mx-auto mb-4 hidden gap-2 rounded-lg bg-gray-100 px-4 py-2 text-center font-bold uppercase text-white lg:flex ">
+      <Image
+        src="/images/misc/E045.svg"
+        alt=""
+        className="w-8"
+        aria-hidden="true"
+        width="20"
+        height="20"
+      />
+      <Link
+        className="font-base text-sm text-primaryDark md:text-lg"
+        target="_blank"
+        href={'https://github.com/datagir/nosgestesclimat/pull/' + PRNumber}>
+        #{PRNumber}
+      </Link>
+      <button
+        onClick={(event) => {
+          event.stopPropagation()
+          clearPRNumber()
+          router.refresh()
+        }}>
+        <Image
+          className="w-6"
+          src="/images/misc/close-plain.svg"
+          alt=""
+          width="1"
+          height="1"
+        />
+      </button>
+    </div>
+  )
+}

--- a/src/app/_components/providers/CheckFixedRegion.tsx
+++ b/src/app/_components/providers/CheckFixedRegion.tsx
@@ -9,8 +9,7 @@ export default function CheckFixedRegion() {
 
   useEffect(() => {
     // Do nothing if region is the same as the user's
-    if (!fixedRegionCode && fixedRegionCode === user?.region?.code) return
-
+    if (!fixedRegionCode || fixedRegionCode === user?.region?.code) return
     const region = countries.find((country) => country.code === fixedRegionCode)
     if (region) {
       updateRegion(region)

--- a/src/app/_components/providers/QueryParamsProvider.tsx
+++ b/src/app/_components/providers/QueryParamsProvider.tsx
@@ -1,9 +1,9 @@
-import { useDataServer } from '@/hooks/useDataServer'
 import { useDebug } from '@/hooks/useDebug'
+import { usePRNumber } from '@/hooks/usePRNumber'
 import { PropsWithChildren } from 'react'
 
 export default function QueryParamsProvider({ children }: PropsWithChildren) {
   useDebug()
-  useDataServer()
+  usePRNumber()
   return children
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -93,7 +93,6 @@ export default async function RootLayout({ children }: PropsWithChildren) {
         {process.env.NEXT_PUBLIC_MATOMO_ID === '1' ? (
           <Script id="matomo">
             {`
-          
             var _paq = window._paq = window._paq || [];
              /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
             _paq.push(["setExcludedQueryParams", ["detail","diapo"]]);
@@ -102,12 +101,31 @@ export default async function RootLayout({ children }: PropsWithChildren) {
               var u="https://stats.data.gouv.fr/";
               _paq.push(['setTrackerUrl', u+'matomo.php']);
               _paq.push(['setSiteId', '153']);
+              // Adds the Matomo V2 tracker
+              _paq.push(['addTracker', 'https://matomo-incubateur-ademe.osc-fr1.scalingo.io/matomo.php', '1'])
               var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
               g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
             })();
           `}
           </Script>
-        ) : null}
+        ) : (
+          <Script id="matomo">
+            {`
+            var _paq = window._paq = window._paq || [];
+            /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+            _paq.push(["setExcludedQueryParams", ["details"]]);
+            _paq.push(['trackPageView']);
+            _paq.push(['enableLinkTracking']);
+            (function() {
+              var u="https://matomo-incubateur-ademe.osc-fr1.scalingo.io/";
+              _paq.push(['setTrackerUrl', u+'matomo.php']);
+              _paq.push(['setSiteId', '2']);
+              var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+              g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+            })();
+          `}
+          </Script>
+        )}
       </head>
 
       <body className={marianne.className}>

--- a/src/hooks/useDataServer.ts
+++ b/src/hooks/useDataServer.ts
@@ -1,27 +1,15 @@
-import { useIsClient } from '@/app/_components/IsClientCtxProvider'
-import { useSearchParams } from 'next/navigation'
-import { useEffect } from 'react'
+import { usePRNumber } from './usePRNumber'
 
 export const useDataServer = () => {
-  const searchParams = useSearchParams()
-
-  const isClient = useIsClient()
-
-  useEffect(() => {
-    const PRInQueryParams = searchParams.get('PR')
-
-    if (PRInQueryParams && isClient) {
-      sessionStorage.setItem('PR', PRInQueryParams)
-    }
-  }, [searchParams, isClient])
-
-  const PR = isClient ? sessionStorage.getItem('PR') : null
-
-  if (PR) {
-    return `https://deploy-preview-${PR}--ecolab-data.netlify.app`
+  const { PRNumber } = usePRNumber()
+  if (PRNumber) {
+    return `https://deploy-preview-${PRNumber}--ecolab-data.netlify.app`
   }
 
   const localUrl = process.env.NEXT_PUBLIC_LOCAL_DATA_SERVER
+  if (localUrl) {
+    return localUrl
+  }
 
-  return localUrl ?? 'https://deploy-preview-2085--ecolab-data.netlify.app'
+  return 'https://deploy-preview-2085--ecolab-data.netlify.app'
 }

--- a/src/hooks/usePRNumber.ts
+++ b/src/hooks/usePRNumber.ts
@@ -1,17 +1,15 @@
 import { useIsClient } from '@/app/_components/IsClientCtxProvider'
 import { useSearchParams } from 'next/navigation'
 
-const PR_NUMBER_KEY = 'PR'
-
 function getPRNumberFromStorage() {
-  return sessionStorage.getItem(PR_NUMBER_KEY) ?? ''
+  return sessionStorage.getItem('PR') ?? ''
 }
 
 function clearPRNumberFromStorage() {
-  sessionStorage.removeItem(PR_NUMBER_KEY)
+  sessionStorage.removeItem('PR')
 }
 
-export function useGetPRNumber(): {
+export function usePRNumber(): {
   PRNumber?: string
   clearPRNumber: () => void
 } {
@@ -37,7 +35,7 @@ export function useGetPRNumber(): {
   }
 
   if (PRNumberFromURL) {
-    sessionStorage.setItem(PR_NUMBER_KEY, PRNumberFromURL)
+    sessionStorage.setItem('PR', PRNumberFromURL)
   }
 
   return {

--- a/src/hooks/useRules.ts
+++ b/src/hooks/useRules.ts
@@ -11,16 +11,19 @@ type Props = {
 }
 
 export function useRules({ lang, region, isOptim = true }: Props) {
-  const locale = useLocale()
-  const { user } = useUser()
   const dataServer = useDataServer()
+
+  const locale = useLocale()
+
+  const { user } = useUser()
+
   const regionCode =
     user?.region?.code != undefined && user?.region?.code !== ''
       ? user?.region?.code
       : region
 
   return useQuery(
-    ['rules', lang, region, isOptim],
+    ['rules', dataServer, lang, region, isOptim],
     () =>
       axios
         .get(

--- a/src/hooks/useSubscribeUser.ts
+++ b/src/hooks/useSubscribeUser.ts
@@ -42,8 +42,6 @@ const saveSimulationInDB = async (data: Simulation) => {
     dataFormatted.situation = formatDataForDB(dataFormatted)
   }
 
-  console.log(dataFormatted)
-
   try {
     const response = await axios.post(
       SAVE_SIMULATION_URL,


### PR DESCRIPTION
Changelog :  : 

- https://github.com/incubateur-ademe/nosgestesclimat-site-nextjs/pull/162
- https://github.com/incubateur-ademe/nosgestesclimat-site-nextjs/pull/165


* fix: use correct Matomo id for preview and dev

* fix: use correct env name

* fix: Met à jour les urls vers la page partenaires

* [Hotfix]: Ajoute redirection manquante /mon-empreinte-carbone (#137)

* fix: redirect to sondages.ngc.fr

* [Hot fix]: Ajoute redirection manquante pour `/mon-empreinte-carbone` (#132)

* fix: use correct Matomo id for preview and dev

* fix: use correct env name

* fix: Add rewrite

---------



* Revert "[Hot fix]: Ajoute redirection manquante pour `/mon-empreinte-carbone` (#132)" (#135)

This reverts commit f44a3a5ac3f26225fced5b68a67eb5ef80608e55.

* fix: Ajoute redirection manquante

---------



* feat: Add hook that loads simulation from URL

* fix: Add missing dep

* feat: Ajoute l'ErrorBoundary Sentry + ErrorFallback (#138)

* feat: use useQuery + add check

* clean

* feat: Remove sid from URL

* Update SimulationFromURLLoader.tsx

* feat: Add hook that loads simulation from URL (#143)

* feat: Add hook that loads simulation from URL

* fix: Add missing dep

* feat: use useQuery + add check

* clean

* feat: Remove sid from URL

* Update SimulationFromURLLoader.tsx

* fix: Corrige la condition dans SERVER_URL

* feat: new way of filtering relevant folded steps

* fix: remove some env var from front-end

* fix: stop calling email simulation every time

* fix: filename capitalization

* feat: use old matomo (only in production)

* fix: check if paq exist before sending events

* fix: fix typo in matomo script

* fix: nouveautés redirect to nouveautes

* feat: new page diffuser

* feat: add kit de diffusion

* fix: github link

* fix: update region based on query params "region"

* fix: change localisation param to region

* fix: use "useIframe" hook

* fix: ignore iframe for fixed region

* fix: set data-region for demo

* fix: disable FAQ link if iframeOnlySimulation param

* fix: disable PR link in nav is !iframeRegion

* fix: disable logo redirection if iframeOnlySimulation param

* nitpick: what's happening when adding a class ?

* fix: show Localisation Banner when region change

* feat: add Localisation Banner in documentation

* fix: disable Localisation Banner when region is fixed

* fix: early return for FAQ banner

* fix: rename boolean variables

* fix: issues label to display

* refactor: clean if statement

* fix: delete data-share option for iframeSimulation

* fix: fix margin from menu when footer is hidden

* feat: reorganize page profil

* feat: add title

* fix: hide empty categories

* feat: remove +0 on actions engagement

* fix: redirect /vie-privée => /vie-privee

* feat: add 'use client' for every client component

* chore: merge artefacts

* build: regenerate the yarn.lock with the forced yarn and node version

* fix(t9n): do not use i18nKeys as default translation value

* fix(t9n): update the UI translations

* Revert "build: regenerate the yarn.lock with the forced yarn and node version"

This reverts commit befd5b39d1cb07d56d7e00fd301f1bf7688bf155.

* pkg: upgrade nosgestesclimat-scripts

* fix(i18next): avoid using any type coercion in Trans components

* fix(t9n): update UI translations

* Revert "pkg: upgrade nosgestesclimat-scripts"

This reverts commit 975c77f4e9e1144a997c04ee58d3ce38c7bf9572.

* pkg: upgrade nosgestesclimat-scripts

* fix(scripts): remove script files previously migrated in nosgestesclimat-scripts

* ci: setup workflow for uploading translation status in PR comments

* ci: fix branche names

* fix: Corrige lien diffuser > partenaires

* pkg: remit yarn.lock with yarn classic

* pkg: upgrade @incubateur-ademe/nosgestesclimat-scripts

* fix(t9n): use \u202f with t function instead of &nbsp; with Trans component

* fix(t9n): add all missing translations in the /fin page

* fix: vie-privée -> vie-privee

* fix(t9n): add missing translation in the Total component

* fix(t9n): add missing translation in the /profil page

* feat: PR in query params is now always acknowledged by front

* Ré-ajoute le matomo V2 👊 (#162)

* fix: correct check for fixedRegion

* chore: cleaning

* chore: remove log

---------