### PR TITLE
Fix: use the order of the sum to sort sub categories - [NGC-372]

### DIFF
--- a/cypress/helpers/categories/checkIfCategoryOrderIsRespected.js
+++ b/cypress/helpers/categories/checkIfCategoryOrderIsRespected.js
@@ -1,4 +1,5 @@
 import { CATEGORIES } from '../../constants/categories'
+import getNamespace from '../../utils/getNamespace'
 
 const categoriesOrderArray = CATEGORIES.map((category) => ({
   key: category,

--- a/cypress/helpers/categories/checkIfCategoryOrderIsRespected.js
+++ b/cypress/helpers/categories/checkIfCategoryOrderIsRespected.js
@@ -7,7 +7,7 @@ const categoriesOrderArray = CATEGORIES.map((category) => ({
 
 export function checkIfCategoryOrderIsRespected(questionId) {
   const indexCurrentCategory = categoriesOrderArray.findIndex(
-    (category) => category.key === questionId.split(' . ')[0]
+    (category) => category.key === getNamespace(questionId)
   )
   cy.log(
     'indexCurrentCategory',

--- a/cypress/utils/getNamespace.js
+++ b/cypress/utils/getNamespace.js
@@ -1,0 +1,3 @@
+export default function getNamespace(ruleName) {
+  return !ruleName ? undefined : ruleName.split(' . ')[0]
+}

--- a/src/app/(layout-with-navigation)/(simulation)/actions/[...dottedName]/_components/ActionDetail.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/actions/[...dottedName]/_components/ActionDetail.tsx
@@ -12,6 +12,7 @@ import {
   useTempEngine,
   useUser,
 } from '@/publicodes-state'
+import getNamespace from '@/publicodes-state/helpers/getNamespace'
 import { NGCRuleNode } from '@/publicodes-state/types'
 import { trackEvent } from '@/utils/matomo/trackEvent'
 import { utils } from 'publicodes'
@@ -60,7 +61,7 @@ export default function ActionDetail({
     .filter(
       (actionDottedName: string) =>
         actionDottedName !== dottedName &&
-        dottedName.split(' . ')[0] === actionDottedName.split(' . ')[0]
+        getNamespace(dottedName) === getNamespace(actionDottedName)
     )
     .map((name: string) => getRuleObject(name))
 
@@ -102,7 +103,7 @@ export default function ActionDetail({
           <FormProvider root={dottedName}>
             <ActionForm
               key={dottedName}
-              category={dottedName.split(' . ')[0]}
+              category={getNamespace(dottedName) ?? ''}
               onComplete={() => {
                 toggleActionChoice(dottedName)
 

--- a/src/app/(layout-with-navigation)/(simulation)/actions/[...dottedName]/_components/ActionDetail.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/actions/[...dottedName]/_components/ActionDetail.tsx
@@ -12,8 +12,7 @@ import {
   useTempEngine,
   useUser,
 } from '@/publicodes-state'
-import getNamespace from '@/publicodes-state/helpers/getNamespace'
-import { NGCRuleNode } from '@/publicodes-state/types'
+import { DottedName, NGCRuleNode } from '@/publicodes-state/types'
 import { trackEvent } from '@/utils/matomo/trackEvent'
 import { utils } from 'publicodes'
 import ActionForm from '../../_components/actions/_components/ActionForm'
@@ -26,6 +25,7 @@ export default function ActionDetail({
 }: {
   params: { dottedName: string[] }
 }) {
+  const { getCategory } = useEngine()
   const pathParamsDottedName = params?.dottedName
 
   const formattedDottedName = pathParamsDottedName
@@ -59,9 +59,8 @@ export default function ActionDetail({
 
   const relatedActions: NGCRuleNode[] = flatActions?.formule?.somme
     .filter(
-      (actionDottedName: string) =>
-        actionDottedName !== dottedName &&
-        getNamespace(dottedName) === getNamespace(actionDottedName)
+      (action: DottedName) =>
+        action !== dottedName && getCategory(dottedName) === getCategory(action)
     )
     .map((name: string) => getRuleObject(name))
 
@@ -103,7 +102,7 @@ export default function ActionDetail({
           <FormProvider root={dottedName}>
             <ActionForm
               key={dottedName}
-              category={getNamespace(dottedName) ?? ''}
+              category={getCategory(dottedName) ?? ''}
               onComplete={() => {
                 toggleActionChoice(dottedName)
 

--- a/src/app/(layout-with-navigation)/(simulation)/actions/[...dottedName]/_components/ActionDetail.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/actions/[...dottedName]/_components/ActionDetail.tsx
@@ -102,7 +102,7 @@ export default function ActionDetail({
           <FormProvider root={dottedName}>
             <ActionForm
               key={dottedName}
-              category={getCategory(dottedName) ?? ''}
+              category={getCategory(dottedName)}
               onComplete={() => {
                 toggleActionChoice(dottedName)
 

--- a/src/app/(layout-with-navigation)/(simulation)/actions/_components/actions/_components/ActionList.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/actions/_components/actions/_components/ActionList.tsx
@@ -1,6 +1,5 @@
 import { getMatomoEventActionAccepted } from '@/constants/matomo'
-import { FormProvider, useUser } from '@/publicodes-state'
-import getNamespace from '@/publicodes-state/helpers/getNamespace'
+import { FormProvider, useEngine, useUser } from '@/publicodes-state'
 import { trackEvent } from '@/utils/matomo/trackEvent'
 import ActionCard from './ActionCard'
 import ActionForm from './ActionForm'
@@ -20,6 +19,7 @@ export default function ActionList({
   focusedAction,
   setFocusedAction,
 }: Props) {
+  const { getCategory } = useEngine()
   const { toggleActionChoice, getCurrentSimulation } = useUser()
 
   const currentSimulation = getCurrentSimulation()
@@ -52,7 +52,7 @@ export default function ActionList({
                 <FormProvider root={action.dottedName}>
                   <ActionForm
                     key={action.dottedName}
-                    category={getNamespace(action.dottedName) ?? ''}
+                    category={getCategory(action.dottedName)}
                     onComplete={() => {
                       toggleActionChoice(action.dottedName)
 

--- a/src/app/(layout-with-navigation)/(simulation)/actions/_components/actions/_components/ActionList.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/actions/_components/actions/_components/ActionList.tsx
@@ -1,5 +1,6 @@
 import { getMatomoEventActionAccepted } from '@/constants/matomo'
 import { FormProvider, useUser } from '@/publicodes-state'
+import getNamespace from '@/publicodes-state/helpers/getNamespace'
 import { trackEvent } from '@/utils/matomo/trackEvent'
 import ActionCard from './ActionCard'
 import ActionForm from './ActionForm'
@@ -51,7 +52,7 @@ export default function ActionList({
                 <FormProvider root={action.dottedName}>
                   <ActionForm
                     key={action.dottedName}
-                    category={action.dottedName.split(' . ')[0]}
+                    category={getNamespace(action.dottedName) ?? ''}
                     onComplete={() => {
                       toggleActionChoice(action.dottedName)
 

--- a/src/app/(layout-with-navigation)/(simulation)/actions/_components/categoryFilters/CategoryFilters.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/actions/_components/categoryFilters/CategoryFilters.tsx
@@ -1,5 +1,6 @@
 'use client'
 import { useForm } from '@/publicodes-state'
+import getNamespace from '@/publicodes-state/helpers/getNamespace'
 import Filter from './_components/Filter'
 
 type Props = {
@@ -10,9 +11,11 @@ export default function CategoryFilters({ actions }: Props) {
   const { categories } = useForm()
 
   const countByCategory = actions.reduce((accumulator: any, action: any) => {
-    const category = action.dottedName.split(' . ')[0]
+    const category = getNamespace(action.dottedName)
 
-    return { ...accumulator, [category]: (accumulator[category] || 0) + 1 }
+    return !category
+      ? accumulator
+      : { ...accumulator, [category]: (accumulator[category] || 0) + 1 }
   }, {})
 
   return (

--- a/src/app/(layout-with-navigation)/(simulation)/actions/_components/categoryFilters/CategoryFilters.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/actions/_components/categoryFilters/CategoryFilters.tsx
@@ -1,6 +1,5 @@
 'use client'
-import { useForm } from '@/publicodes-state'
-import getNamespace from '@/publicodes-state/helpers/getNamespace'
+import { useEngine, useForm } from '@/publicodes-state'
 import Filter from './_components/Filter'
 
 type Props = {
@@ -9,9 +8,10 @@ type Props = {
 
 export default function CategoryFilters({ actions }: Props) {
   const { categories } = useForm()
+  const { getCategory } = useEngine()
 
   const countByCategory = actions.reduce((accumulator: any, action: any) => {
-    const category = getNamespace(action.dottedName)
+    const category = getCategory(action.dottedName)
 
     return !category
       ? accumulator

--- a/src/app/(layout-with-navigation)/(simulation)/actions/_helpers/filterIrrelevantActions.ts
+++ b/src/app/(layout-with-navigation)/(simulation)/actions/_helpers/filterIrrelevantActions.ts
@@ -1,23 +1,23 @@
-import { useEngine } from '@/publicodes-state'
+import getNamespace from '@/publicodes-state/helpers/getNamespace'
 
 // TODO : refactor this function which seems overly complex
 export const filterIrrelevantActions = ({ actions, actionChoices }: any) => {
-  const { getCategory } = useEngine()
-
   // pour chaque action choisie, on regarde ses frères et soeurs en récupérant
   // la catégorie de l'action
   const testedActions = Object.keys(actionChoices || {})?.reduce(
     (acc: any[], actionChoiceKey: any) => {
       if (!actionChoices[actionChoiceKey]) return acc
 
-      const category = getCategory(actionChoiceKey)
+      // NOTE: we can't use the `getCategory` function from the `useEngine` hook
+      // here.
+      const category = getNamespace(actionChoiceKey)
 
       const actionObject = actions.find((action: any) => {
         return action.dottedName === actionChoiceKey
       })
 
       const sameCategoryActions = actions.filter((action: any) => {
-        return getCategory(action.dottedName) === category
+        return getNamespace(action.dottedName) === category
       })
 
       const actionsWithIrrelevant = sameCategoryActions.map((action: any) => {

--- a/src/app/(layout-with-navigation)/(simulation)/actions/_helpers/filterIrrelevantActions.ts
+++ b/src/app/(layout-with-navigation)/(simulation)/actions/_helpers/filterIrrelevantActions.ts
@@ -1,20 +1,23 @@
-import getNamespace from '@/publicodes-state/helpers/getNamespace'
+import { useEngine } from '@/publicodes-state'
 
 // TODO : refactor this function which seems overly complex
 export const filterIrrelevantActions = ({ actions, actionChoices }: any) => {
-  // pour chaque action choisie, on regarde ses frères et soeurs en récupérant la catégorie de l'action
+  const { getCategory } = useEngine()
+
+  // pour chaque action choisie, on regarde ses frères et soeurs en récupérant
+  // la catégorie de l'action
   const testedActions = Object.keys(actionChoices || {})?.reduce(
     (acc: any[], actionChoiceKey: any) => {
       if (!actionChoices[actionChoiceKey]) return acc
 
-      const category = getNamespace(actionChoiceKey)
+      const category = getCategory(actionChoiceKey)
 
       const actionObject = actions.find((action: any) => {
         return action.dottedName === actionChoiceKey
       })
 
       const sameCategoryActions = actions.filter((action: any) => {
-        return getNamespace(action.dottedName) === category
+        return getCategory(action.dottedName) === category
       })
 
       const actionsWithIrrelevant = sameCategoryActions.map((action: any) => {

--- a/src/app/(layout-with-navigation)/(simulation)/actions/_helpers/filterIrrelevantActions.ts
+++ b/src/app/(layout-with-navigation)/(simulation)/actions/_helpers/filterIrrelevantActions.ts
@@ -1,3 +1,5 @@
+import getNamespace from '@/publicodes-state/helpers/getNamespace'
+
 // TODO : refactor this function which seems overly complex
 export const filterIrrelevantActions = ({ actions, actionChoices }: any) => {
   // pour chaque action choisie, on regarde ses frères et soeurs en récupérant la catégorie de l'action
@@ -5,14 +7,14 @@ export const filterIrrelevantActions = ({ actions, actionChoices }: any) => {
     (acc: any[], actionChoiceKey: any) => {
       if (!actionChoices[actionChoiceKey]) return acc
 
-      const category = actionChoiceKey.split(' . ')[0]
+      const category = getNamespace(actionChoiceKey)
 
       const actionObject = actions.find((action: any) => {
         return action.dottedName === actionChoiceKey
       })
 
       const sameCategoryActions = actions.filter((action: any) => {
-        return action.dottedName.split(' . ')[0] === category
+        return getNamespace(action.dottedName) === category
       })
 
       const actionsWithIrrelevant = sameCategoryActions.map((action: any) => {

--- a/src/app/(layout-with-navigation)/(simulation)/actions/page.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/actions/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useForm, useTempEngine, useUser } from '@/publicodes-state'
+import getNamespace from '@/publicodes-state/helpers/getNamespace'
 import { useState } from 'react'
 import ActionsTutorial from './_components/ActionsTutorial'
 import OptionBar from './_components/OptionBar'
@@ -40,7 +41,7 @@ export default function ActionsPage({
   })
 
   const actionsDisplayed = actions.filter((action: any) =>
-    category ? action.dottedName.split(' . ')[0] === category : true
+    category ? getNamespace(action.dottedName) === category : true
   )
 
   //TODO this is quite a bad design

--- a/src/app/(layout-with-navigation)/(simulation)/actions/page.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/actions/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { useForm, useTempEngine, useUser } from '@/publicodes-state'
-import getNamespace from '@/publicodes-state/helpers/getNamespace'
+import { useEngine, useForm, useTempEngine, useUser } from '@/publicodes-state'
 import { useState } from 'react'
 import ActionsTutorial from './_components/ActionsTutorial'
 import OptionBar from './_components/OptionBar'
@@ -40,8 +39,10 @@ export default function ActionsPage({
     actionChoices,
   })
 
+  const { getCategory } = useEngine()
+
   const actionsDisplayed = actions.filter((action: any) =>
-    category ? getNamespace(action.dottedName) === category : true
+    category ? getCategory(action.dottedName) === category : true
   )
 
   //TODO this is quite a bad design

--- a/src/app/(layout-with-navigation)/(simulation)/actions/page.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/actions/page.tsx
@@ -14,6 +14,7 @@ export default function ActionsPage({
 }: {
   searchParams: { [key: string]: string | string[] | undefined }
 }) {
+  const { getCategory } = useEngine()
   const [radical, setRadical] = useState(true)
   const metric = (searchParams.métrique || '') as string
 
@@ -38,8 +39,6 @@ export default function ActionsPage({
     getRuleObject,
     actionChoices,
   })
-
-  const { getCategory } = useEngine()
 
   const actionsDisplayed = actions.filter((action: any) =>
     category ? getCategory(action.dottedName) === category : true

--- a/src/app/documentation/[...slug]/_components/documentationRouter/DocumentationServer.tsx
+++ b/src/app/documentation/[...slug]/_components/documentationRouter/DocumentationServer.tsx
@@ -50,7 +50,9 @@ export default async function DocumentationServer({
   return (
     <div className="mt-4 w-full max-w-4xl p-4 md:mx-auto md:py-8">
       <Title
-        title={`${rule.icônes ?? ''} ${capitalizeString(getRuleTitle(rule))}`}
+        title={`${rule.icônes ?? ''} ${capitalizeString(
+          getRuleTitle({ ...rule, dottedName: ruleName })
+        )}`}
         data-cypress-id="documentation-title"
       />
 

--- a/src/app/documentation/_components/DocumentationLandingCard.tsx
+++ b/src/app/documentation/_components/DocumentationLandingCard.tsx
@@ -4,7 +4,7 @@ import Link from '@/components/Link'
 import Card from '@/design-system/layout/Card'
 import Emoji from '@/design-system/utils/Emoji'
 import { getBackgroundColor } from '@/helpers/getCategoryColorClass'
-import getNamespace from '@/publicodes-state/helpers/getNamespace'
+import { useEngine } from '@/publicodes-state'
 import { NGCRule } from '@/publicodes-state/types'
 import Markdown from 'markdown-to-jsx'
 import { utils } from 'publicodes'
@@ -19,7 +19,8 @@ export default function DocumentationLandingCard({
   summary,
   rule,
 }: Props) {
-  const category = getNamespace(dottedName)
+  const { getCategory } = useEngine()
+  const category = getCategory(dottedName)
 
   return (
     <Card

--- a/src/app/documentation/_components/DocumentationLandingCard.tsx
+++ b/src/app/documentation/_components/DocumentationLandingCard.tsx
@@ -4,6 +4,7 @@ import Link from '@/components/Link'
 import Card from '@/design-system/layout/Card'
 import Emoji from '@/design-system/utils/Emoji'
 import { getBackgroundColor } from '@/helpers/getCategoryColorClass'
+import getNamespace from '@/publicodes-state/helpers/getNamespace'
 import { NGCRule } from '@/publicodes-state/types'
 import Markdown from 'markdown-to-jsx'
 import { utils } from 'publicodes'
@@ -18,7 +19,7 @@ export default function DocumentationLandingCard({
   summary,
   rule,
 }: Props) {
-  const category = dottedName.split(' . ')[0]
+  const category = getNamespace(dottedName)
 
   return (
     <Card

--- a/src/helpers/publicodes/getRuleTitle.ts
+++ b/src/helpers/publicodes/getRuleTitle.ts
@@ -2,7 +2,7 @@ import { NGCRule } from '@/publicodes-state/types'
 import { utils } from 'publicodes'
 
 export const getRuleTitle = (
-  rule: NGCRule & { dottedName: string; titre: string }
+  rule: NGCRule & { dottedName: string; titre?: string }
 ) => {
   return rule?.titre ?? utils.nameLeaf(rule.dottedName)
 }

--- a/src/publicodes-state/helpers/getNamespace.ts
+++ b/src/publicodes-state/helpers/getNamespace.ts
@@ -1,19 +1,36 @@
 import { DottedName } from '@/publicodes-state/types'
 
 /**
- * Returns the namespace of a dotted name.
+ * Returns the namespace of a rule. A level can be specified to get a specific
+ * part of the namespace.
  *
- * @param {string} rule - The dotted name of the rule, it expects to be a valid
+ * @param {DottedName} rule - The dotted name of the rule, it expects to be a valid
  * dotted name.
+ * @param {number} level - The level of the namespace, by default it is 1.
  *
  * @example
- * getNamespace('contrat salarié . ancienneté') // 'contrat salarié'
- * getNamespace('contrat salarié') // 'contrat salarié'
+ * getNamespace('contrat salarié . ancienneté . ancienneté') // 'contrat salarié'
+ * getNamespace('contrat salarié . ancienneté . ancienneté', 2) // 'contrat salarié . ancienneté'
+ * getNamespace('contrat salarié', 3) // 'contrat salarié'
  * getNamespace(null) // null
  *
  */
 export default function getNamespace(
-  rule?: DottedName | null
+  rule: DottedName | undefined | null,
+  level: number = 1
 ): string | undefined {
-  return !rule ? undefined : rule.split(' . ')[0]
+  if (rule === undefined || rule === null) {
+    return undefined
+  }
+  const splittedRule = rule.split(' . ')
+
+  if (splittedRule.length < level) {
+    return rule
+  }
+  if (level === 1) {
+    return splittedRule[0]
+  }
+  if (level > 1) {
+    return splittedRule.slice(0, level).join(' . ')
+  }
 }

--- a/src/publicodes-state/helpers/getNamespace.ts
+++ b/src/publicodes-state/helpers/getNamespace.ts
@@ -1,0 +1,19 @@
+import { DottedName } from '@/publicodes-state/types'
+
+/**
+ * Returns the namespace of a dotted name.
+ *
+ * @param {string} rule - The dotted name of the rule, it expects to be a valid
+ * dotted name.
+ *
+ * @example
+ * getNamespace('contrat salarié . ancienneté') // 'contrat salarié'
+ * getNamespace('contrat salarié') // 'contrat salarié'
+ * getNamespace(null) // null
+ *
+ */
+export default function getNamespace(
+  rule?: DottedName | null
+): string | undefined {
+  return !rule ? undefined : rule.split(' . ')[0]
+}

--- a/src/publicodes-state/hooks/useEngine/index.ts
+++ b/src/publicodes-state/hooks/useEngine/index.ts
@@ -1,6 +1,7 @@
+import getNamespace from '@/publicodes-state/helpers/getNamespace'
 import { useContext } from 'react'
 import simulationContext from '../../providers/simulationProvider/context'
-import { NodeValue } from '../../types'
+import { DottedName, NodeValue } from '../../types'
 
 /**
  * A hook that make available some basic functions on the engine (and the engine itself).
@@ -19,7 +20,8 @@ export default function useEngine() {
     return Number(nodeValue) === nodeValue ? nodeValue : 0
   }
 
-  const getCategory = (dottedName: string): string => dottedName.split(' . ')[0]
+  const getCategory = (dottedName: DottedName): string =>
+    getNamespace(dottedName) ?? ''
 
   const getSubcategories = (dottedName: string): string[] =>
     safeGetRule(dottedName)?.rawNode?.formule?.somme

--- a/src/publicodes-state/hooks/useEngine/index.ts
+++ b/src/publicodes-state/hooks/useEngine/index.ts
@@ -21,7 +21,7 @@ export default function useEngine() {
   }
 
   const getCategory = (dottedName: DottedName): string =>
-    getNamespace(dottedName) ?? ''
+    getNamespace(dottedName, 1) ?? ''
 
   const getSubcategories = (dottedName: string): string[] =>
     safeGetRule(dottedName)?.rawNode?.formule?.somme

--- a/src/publicodes-state/hooks/useForm/useNavigation.ts
+++ b/src/publicodes-state/hooks/useForm/useNavigation.ts
@@ -1,3 +1,4 @@
+import getNamespace from '@/publicodes-state/helpers/getNamespace'
 import { useMemo } from 'react'
 
 type Props = {
@@ -12,6 +13,11 @@ export default function useNavigation({
   currentQuestion,
   setCurrentQuestion,
 }: Props) {
+  const currentQuestionNamespace = useMemo<string | undefined>(
+    () => getNamespace(currentQuestion),
+    [currentQuestion]
+  )
+
   const currentQuestionIndex = useMemo<number>(
     () => (currentQuestion ? relevantQuestions?.indexOf(currentQuestion) : 0),
     [relevantQuestions, currentQuestion]
@@ -28,19 +34,22 @@ export default function useNavigation({
 
   const isLastQuestionOfCategory = useMemo<boolean>(
     () =>
-      relevantQuestions[currentQuestionIndex + 1]?.split(' . ')[0] !==
-      currentQuestion?.split(' . ')[0],
-    [currentQuestion, currentQuestionIndex, relevantQuestions]
+      getNamespace(relevantQuestions[currentQuestionIndex + 1]) !==
+      currentQuestionNamespace,
+    [currentQuestionNamespace, currentQuestionIndex, relevantQuestions]
   )
+
   const isFirstQuestionOfCategory = useMemo<boolean>(
     () =>
-      relevantQuestions[currentQuestionIndex - 1]?.split(' . ')[0] !==
-      currentQuestion?.split(' . ')[0],
-    [currentQuestion, currentQuestionIndex, relevantQuestions]
+      getNamespace(relevantQuestions[currentQuestionIndex - 1]) !==
+      currentQuestionNamespace,
+    [currentQuestionNamespace, currentQuestionIndex, relevantQuestions]
   )
 
   const gotoPrevQuestion = (): string | undefined => {
-    if (noPrevQuestion) return
+    if (noPrevQuestion) {
+      return undefined
+    }
 
     const newCurrentQuestion = relevantQuestions[currentQuestionIndex - 1]
 
@@ -49,7 +58,9 @@ export default function useNavigation({
     return newCurrentQuestion
   }
   const gotoNextQuestion = (): string | undefined => {
-    if (noNextQuestion) return
+    if (noNextQuestion) {
+      return undefined
+    }
 
     const newCurrentQuestion = relevantQuestions[currentQuestionIndex + 1]
 

--- a/src/publicodes-state/hooks/useRule/useContent.ts
+++ b/src/publicodes-state/hooks/useRule/useContent.ts
@@ -1,5 +1,6 @@
 'use client'
 
+import getNamespace from '@/publicodes-state/helpers/getNamespace'
 import { useMemo } from 'react'
 import { NGCRuleNode, Suggestion } from '../../types'
 
@@ -10,7 +11,7 @@ type Props = {
 
 export default function useContent({ dottedName, rule }: Props) {
   const category = useMemo<string>(
-    () => dottedName.split(' . ')[0],
+    () => getNamespace(dottedName) ?? '',
     [dottedName]
   )
 

--- a/src/publicodes-state/hooks/useRule/useNotifications.ts
+++ b/src/publicodes-state/hooks/useRule/useNotifications.ts
@@ -1,5 +1,6 @@
 'use client'
 
+import getNamespace from '@/publicodes-state/helpers/getNamespace'
 import { useMemo } from 'react'
 import { NGCEvaluatedNode, Situation } from '../../types'
 
@@ -23,7 +24,7 @@ export default function useNotifications({
           const splitNotification = notification.split(' . ')
           // If notification dottedName has only two names (itself and its category), it should apply to the whole category.
           if (splitNotification.length <= 2) {
-            return splitNotification[0] === dottedName.split(' . ')[0]
+            return splitNotification[0] === getNamespace(dottedName)
           }
           // If not, it should apply to the subcategory
           return splitNotification[1] === dottedName.split(' . ')[1]

--- a/src/publicodes-state/providers/formProvider/useCurrent.ts
+++ b/src/publicodes-state/providers/formProvider/useCurrent.ts
@@ -1,3 +1,4 @@
+import getNamespace from '@/publicodes-state/helpers/getNamespace'
 import { useCallback, useState } from 'react'
 
 /**
@@ -13,8 +14,10 @@ export default function useCurrent() {
   const exportedSetCurrentQuestion = useCallback(
     (newCurrentQuestion: string | null) => {
       setCurrentQuestion(newCurrentQuestion)
-      if (newCurrentQuestion)
-        setCurrentCategory(newCurrentQuestion.split(' . ')[0])
+      const newCurrentQuestionNamespace = getNamespace(newCurrentQuestion)
+      if (newCurrentQuestion && newCurrentQuestionNamespace) {
+        setCurrentCategory(newCurrentQuestionNamespace)
+      }
     },
     [setCurrentQuestion, setCurrentCategory]
   )

--- a/src/publicodes-state/providers/simulationProvider/index.tsx
+++ b/src/publicodes-state/providers/simulationProvider/index.tsx
@@ -74,7 +74,6 @@ export default function SimulationProvider({
   })
 
   const { categories, subcategories } = useCategories({
-    engine: pristineEngine,
     everyRules,
     root,
     safeGetRule,

--- a/src/publicodes-state/providers/simulationProvider/index.tsx
+++ b/src/publicodes-state/providers/simulationProvider/index.tsx
@@ -75,6 +75,7 @@ export default function SimulationProvider({
 
   const { categories, subcategories } = useCategories({
     engine: pristineEngine,
+    everyRules,
     root,
     safeGetRule,
     order: categoryOrder,

--- a/src/publicodes-state/providers/simulationProvider/useCategories.ts
+++ b/src/publicodes-state/providers/simulationProvider/useCategories.ts
@@ -1,7 +1,6 @@
 import { useMemo } from 'react'
-import { DottedName, Engine, NGCRuleNode } from '../../types'
+import { DottedName, NGCRuleNode } from '../../types'
 type Props = {
-  engine: Engine
   everyRules: DottedName[]
   root: string
   safeGetRule: (rule: string) => NGCRuleNode | null
@@ -9,7 +8,6 @@ type Props = {
 }
 
 export default function useCategories({
-  engine,
   everyRules,
   root,
   safeGetRule,
@@ -41,7 +39,7 @@ export default function useCategories({
         [currentValue]: subCat,
       }
     }, {})
-  }, [categories, safeGetRule, engine, everyRules])
+  }, [categories, safeGetRule, everyRules])
 
   return { categories, subcategories }
 }


### PR DESCRIPTION
## Changelog

- Use the order of the sum to sort sub categories instead of their values
- Factorize some `.split(' . ')[0]` with the helper function `getNamespace`

> [!IMPORTANT]
> We need to wait for the next model's release to patch the question order. https://github.com/incubateur-ademe/nosgestesclimat/commit/7507d4e7ff8b777068e60d8a055fb652df9b86d1