### PR TITLE
Ajoute un paragraphe sur notre page mentions légales

### DIFF
--- a/src/components/mdx/MDXContent.tsx
+++ b/src/components/mdx/MDXContent.tsx
@@ -19,5 +19,9 @@ export default function MDXContent({ contentFr, contentEn }: Props) {
     locale: locale ?? 'fr',
   })
 
-  return <Content />
+  return (
+    <div className="markdown">
+      <Content />
+    </div>
+  )
 }

--- a/src/locales/pages/en/about.mdx
+++ b/src/locales/pages/en/about.mdx
@@ -1,31 +1,29 @@
-# About us
+# About us 🦔
 
 ## What is it?
 
 This simulator enables you to assess your individual carbon footprint
-and by major categories (food, transport,
-housing, miscellaneous, societal services), compare it with climate
+carbon footprint and by major category (food, transport
+(food, transport, housing, miscellaneous, social services), compare it with
 climate targets and, above all, to take action at your own level
-with personalized actions based on your answers.
+with personalised actions based on your answers.
 
-Based on an [analysis of existing calculators in early
+Based on an [analysis of existing calculators at the beginning of
 2020](https://abc-transitionbascarbone.fr/wp-content/uploads/2022/03/analyse-des-calculateurs-dempreinte-carbone-individuelle-a-lorigine-de-nos-gestes-climat-vf-.pdf),
 it is based on the MicMac model from the associations [Avenir
 Climatique](https://avenirclimatique.org/les-outils/) and
-
 <a href="https://www.taca.asso.fr/">TaCa</a>.
 
 ## Who is developing it?
 
 This carbon calculator has been developed by the [Agence de la transition
-écologique](https://www.ademe.fr/) (ADEME) and
-
+transition](https://www.ademe.fr/) (ADEME) and
 <a href="https://beta.gouv.fr/">beta.gouv.fr</a>, in partnership with
-<a href="https://www.associationbilancarbone.fr/">bilan Carbone</a>Association (ABC).
+<a href="https://www.associationbilancarbone.fr/">bilan Carbone</a>Association
+(ABC).
 
 The code for this site <a href="https://github.com/betagouv/ecolab-data">is free</a>.
 Immerse yourself in our carbon models by exploring the
-
 <a href="/documentation">documentation</a>.
 
 ## News
@@ -41,86 +39,25 @@ A selection of audience statistics is publicly available <a href="/stats">on our
 
 ## Privacy policy
 
-We collect anonymized data for the sole purpose of improving this
+We collect anonymised data only to improve this simulator
 simulator.
 
 <a href="/vie-privée">🍪 Our privacy policy</a>
 
+## Legal notice
+
+Our disclaimer is available [on our disclaimer page
+page](/legal-disclaimers).
+
 ## How to integrate this simulator into your site?
 
-We tell you everything on our <a href="/partenaires">partnerships</a> page.
+We'll tell you everything on our <a href="/partenaires">partners</a> page.
 
 ## Contact us
 
 You can contact us via <a href="/contact">our contact form</a>.
+
 ## Budget
 
-The team budget is available on our <a href="/budget">"Budget" page</a>.
+The team's budget is available on our <a href="/budget">"Budget" page</a>.
 
-## Legal notice
-
-### Platform publisher :
-
-The "Nos Gestes Climat" Platform is published by :
-
-The French Agency for Ecological Transition (ADEME):
-
-20, avenue du Grésillé
-BP 90406
-49004 Angers Cedex 01
-France
-
-Phone number: 02 41 20 41 20
-
-### Publication manager
-
-The publication director is Mr. Boris RAVIGNON, Acting Chairman and CEO of ADEME.
-
-### Platform hosting
-
-This platform is hosted by :
-Vercel Inc.
-440 N Barranca Ave #4133
-Covina, CA 91723
-United States
-
-The site is hosted on Vercel. It's a static site served via a CDN.
-
-### Accessibility
-
-The site is partially compliant with digital accessibility standards.
-
-We have carried out [an initial
-audit](https://github.com/datagir/nosgestesclimat-site/issues/350),
-which has been fully corrected. In the spring of 2022, we carried out a second
-audit by Access 42.
-
-The accessibility declaration can be viewed via [the dedicated
-dedicated](/accessibility) page.
-
-To find out more about the French government's digital accessibility policy: http://references.modernisation.gouv.fr/accessibilite-numerique
-
-If you encounter an accessibility problem that prevents you from accessing
-content or functionality, please let us know:
-
-- <a href="/contact">via our contact form</a>
-- via rgaa@ademe.fr
-
-If you do not receive a prompt response from us, you have the right to send your grievances
-to the Défenseur des droits.
-To contact him, you can :
-
-- Use the online contact form here : <a target="_blank" rel="noopener noreferrer" href="https://formulaire.defenseurdesdroits.fr/code/afficher.php?ETAPE=accueil_2016">https://formulaire.defenseurdesdroits.fr/code/afficher.php?ETAPE=accueil_2016</a>
-- Call 09 69 39 00 00 (Monday to Friday, 8am to 8pm)
-- Send a letter (no postage required) to the following address: Défenseur des droits, Libre réponse 71120, 75342 Paris CEDEX 07.
-
-### Security
-
-The site is protected by an electronic certificate, which for the vast majority of
-by a padlock. This protection contributes to the confidentiality of exchanges.
-Under no circumstances will the services associated with the platform be used to send e-mails
-to ask for personal information.
-
-### Terms and conditions of use
-
-They are available on <a href="/cgu">this page</a>.

--- a/src/locales/pages/fr/about.mdx
+++ b/src/locales/pages/fr/about.mdx
@@ -44,6 +44,11 @@ simulateur.
 
 [🍪 Notre politique de confidentialité](/vie-privée)
 
+## Mentions légales
+
+Nos mentions légales sont disponibles [sur notre page mentions
+légales](/mentions-legales).
+
 ## Comment intégrer ce simulateur dans votre site ?
 
 On vous dit tout sur notre page [partenaires](/partenaires).


### PR DESCRIPTION
Il manquait un lien vers notre page /mention-legales (nulle part référencée sur le site).