### PR TITLE
fix: filter quotes to get rulename in safeGetSituation (NGC-457)

### DIFF
--- a/src/publicodes-state/helpers/safeGetSituation.ts
+++ b/src/publicodes-state/helpers/safeGetSituation.ts
@@ -25,21 +25,20 @@ export const safeGetSituation = ({
       if (
         typeof situation[ruleName] === 'string' &&
         situation[ruleName] !== 'oui' &&
-        situation[ruleName] !== 'non'
+        situation[ruleName] !== 'non' &&
+        !everyRules.includes(
+          `${ruleName} . ${(situation[ruleName] as string)?.replaceAll(
+            "'",
+            ''
+          )}`
+        )
       ) {
-        const stringNodeValue = situation[ruleName] as string
-        if (
-          !everyRules.includes(
-            `${ruleName} . ${stringNodeValue.replaceAll("'", '')}`
-          )
-        ) {
-          const error = new Error(
-            `error trying to use "${ruleName}" answer from the user situation: "${situation[ruleName]}" doesn't exist in the model`
-          )
-          console.warn(error)
-          captureException(error)
-          return true
-        }
+        const error = new Error(
+          `error trying to use "${ruleName}" answer from the user situation: "${situation[ruleName]}" doesn't exist in the model`
+        )
+        console.warn(error)
+        captureException(error)
+        return true
       }
     }
   )

--- a/src/publicodes-state/helpers/safeGetSituation.ts
+++ b/src/publicodes-state/helpers/safeGetSituation.ts
@@ -1,11 +1,11 @@
 import { captureException } from '@sentry/react'
-import { DottedName } from '../types'
+import { DottedName, Situation } from '../types'
 
 export const safeGetSituation = ({
   situation,
   everyRules,
 }: {
-  situation: Record<DottedName, string>
+  situation: Situation
   everyRules: DottedName[]
 }): any => {
   const unsupportedDottedNamesFromSituation = Object.keys(situation).filter(
@@ -25,17 +25,21 @@ export const safeGetSituation = ({
       if (
         typeof situation[ruleName] === 'string' &&
         situation[ruleName] !== 'oui' &&
-        situation[ruleName] !== 'non' &&
-        !everyRules.includes(
-          `${ruleName} . ${situation[ruleName]?.replaceAll("'", '')}`
-        )
+        situation[ruleName] !== 'non'
       ) {
-        const error = new Error(
-          `error trying to use "${ruleName}" answer from the user situation: "${situation[ruleName]}" doesn't exist in the model`
-        )
-        console.warn(error)
-        captureException(error)
-        return true
+        const stringNodeValue = situation[ruleName] as string
+        if (
+          !everyRules.includes(
+            `${ruleName} . ${stringNodeValue.replaceAll("'", '')}`
+          )
+        ) {
+          const error = new Error(
+            `error trying to use "${ruleName}" answer from the user situation: "${situation[ruleName]}" doesn't exist in the model`
+          )
+          console.warn(error)
+          captureException(error)
+          return true
+        }
       }
     }
   )

--- a/src/publicodes-state/helpers/safeGetSituation.ts
+++ b/src/publicodes-state/helpers/safeGetSituation.ts
@@ -1,11 +1,11 @@
 import { captureException } from '@sentry/react'
-import { DottedName, Situation } from '../types'
+import { DottedName } from '../types'
 
 export const safeGetSituation = ({
   situation,
   everyRules,
 }: {
-  situation: Situation
+  situation: Record<DottedName, string>
   everyRules: DottedName[]
 }): any => {
   const unsupportedDottedNamesFromSituation = Object.keys(situation).filter(
@@ -26,7 +26,9 @@ export const safeGetSituation = ({
         typeof situation[ruleName] === 'string' &&
         situation[ruleName] !== 'oui' &&
         situation[ruleName] !== 'non' &&
-        !everyRules.includes(`${ruleName} . ${situation[ruleName]}`)
+        !everyRules.includes(
+          `${ruleName} . ${situation[ruleName]?.replaceAll("'", '')}`
+        )
       ) {
         const error = new Error(
           `error trying to use "${ruleName}" answer from the user situation: "${situation[ruleName]}" doesn't exist in the model`


### PR DESCRIPTION
Pb avec le fameux `"'réponse'"` de la situation... Pour récupérer le nom de la règle complet via la réponse, il faut supprimer les guillemets