### PR TITLE
[Aide à la saisie] set float as answer value and set total km instead of "real" km to be consistent with the model (NGC-389)

### DIFF
--- a/src/components/questions/voiture/JourneysInput.tsx
+++ b/src/components/questions/voiture/JourneysInput.tsx
@@ -17,7 +17,7 @@ const periods: Record<string, number> = {
   year: 1,
 }
 
-function roundValue(value: number, precision: number = 10): number {
+function roundFloat(value: number, precision: number = 10): number {
   return Math.round(value * precision) / precision
 }
 
@@ -52,7 +52,7 @@ export default function JourneysInput({ question }: Props) {
           periods[currentValue.period],
       0
     )
-    const roundedTotal = roundValue(rawTotal, 10)
+    const roundedTotal = roundFloat(rawTotal)
     return roundedTotal
   }, [journeys])
 
@@ -70,13 +70,13 @@ export default function JourneysInput({ question }: Props) {
               periods[currentValue.period],
           0
         ) / total
-      const roundedAveragePassengers = roundValue(rawAveragePassengers, 10)
+      const roundedAveragePassengers = roundFloat(rawAveragePassengers)
       return roundedAveragePassengers
     }
   }, [journeys, total])
 
   const totalForOnePassenger = useMemo(
-    () => (journeys.length ? roundValue(total / averagePassengers, 10) : 0),
+    () => (journeys.length ? roundFloat(total / averagePassengers) : 0),
     [journeys, total, averagePassengers]
   )
 

--- a/src/components/questions/voiture/JourneysInput.tsx
+++ b/src/components/questions/voiture/JourneysInput.tsx
@@ -17,6 +17,10 @@ const periods: Record<string, number> = {
   year: 1,
 }
 
+function roundValue(value: number, precision: number = 10): number {
+  return Math.round(value * precision) / precision
+}
+
 export default function JourneysInput({ question }: Props) {
   const { setValue } = useRule(question)
 
@@ -48,7 +52,7 @@ export default function JourneysInput({ question }: Props) {
           periods[currentValue.period],
       0
     )
-    const roundedTotal = Math.round(rawTotal * 10) / 10
+    const roundedTotal = roundValue(rawTotal, 10)
     return roundedTotal
   }, [journeys])
 
@@ -66,15 +70,13 @@ export default function JourneysInput({ question }: Props) {
               periods[currentValue.period],
           0
         ) / total
-      const roundedAveragePassengers =
-        Math.round(rawAveragePassengers * 10) / 10
+      const roundedAveragePassengers = roundValue(rawAveragePassengers, 10)
       return roundedAveragePassengers
     }
   }, [journeys, total])
 
   const totalForOnePassenger = useMemo(
-    () =>
-      journeys.length ? Math.round((total * 10) / averagePassengers) / 10 : 0,
+    () => (journeys.length ? roundValue(total / averagePassengers, 10) : 0),
     [journeys, total, averagePassengers]
   )
 

--- a/src/components/questions/voiture/JourneysInput.tsx
+++ b/src/components/questions/voiture/JourneysInput.tsx
@@ -39,24 +39,24 @@ export default function JourneysInput({ question }: Props) {
     }
   }, [journeys, isInitialized, question])
 
-  const total = useMemo(
-    () =>
-      journeys.reduce(
-        (accumulator, currentValue) =>
-          accumulator +
-          currentValue.distance *
-            currentValue.reccurrence *
-            periods[currentValue.period],
-        0
-      ),
-    [journeys]
-  )
+  const total = useMemo(() => {
+    const rawTotal = journeys.reduce(
+      (accumulator, currentValue) =>
+        accumulator +
+        currentValue.distance *
+          currentValue.reccurrence *
+          periods[currentValue.period],
+      0
+    )
+    const roundedTotal = Math.round(rawTotal * 10) / 10
+    return roundedTotal
+  }, [journeys])
 
   const averagePassengers = useMemo(() => {
     if (!total) {
       return 1
     } else {
-      return (
+      const rawAveragePassengers =
         journeys.reduce(
           (accumulator, currentValue) =>
             accumulator +
@@ -66,29 +66,27 @@ export default function JourneysInput({ question }: Props) {
               periods[currentValue.period],
           0
         ) / total
-      )
+      const roundedAveragePassengers =
+        Math.round(rawAveragePassengers * 10) / 10
+      return roundedAveragePassengers
     }
   }, [journeys, total])
 
   const totalForOnePassenger = useMemo(
-    () => (journeys.length ? total / averagePassengers : 0),
+    () =>
+      journeys.length ? Math.round((total * 10) / averagePassengers) / 10 : 0,
     [journeys, total, averagePassengers]
   )
-  const prevTotalForOnePassenger = useRef(totalForOnePassenger)
+
+  const prevTotal = useRef(total)
 
   useEffect(() => {
-    if (prevTotalForOnePassenger.current !== totalForOnePassenger) {
-      setValue(totalForOnePassenger.toFixed(1), question)
-      setNumPassengers(averagePassengers.toFixed(1))
+    if (prevTotal.current !== total) {
+      setValue(total, question)
+      setNumPassengers(averagePassengers)
     }
-    prevTotalForOnePassenger.current = totalForOnePassenger
-  }, [
-    totalForOnePassenger,
-    averagePassengers,
-    setValue,
-    setNumPassengers,
-    question,
-  ])
+    prevTotal.current = total
+  }, [total, averagePassengers, setValue, setNumPassengers, question])
 
   return (
     <>


### PR DESCRIPTION
Je corrige ici :

- L'aide à la saisie qui est cassée actuellement à cause de mon script dans safeGetSituation car la réponse des km et voyageur est un string (à cause du toFixed)
- Le nombre de kilomètre qu'on set dans la situation, pour la cohérence du calcul il faut donner au moteur le nmbre de km totaux qui se charge ensuite de faire la division (on divisait deux fois par le nombre de voyageurs là). Dans la toute première version on avait une variable spécifique qui évitait ça mais on a simplifié (ce qui est très bien)

Ça vaut peut etre le coup de mettre un test e2e la dessus ?