### PR TITLE
fix: correctly decode rule name from URL

### DIFF
--- a/src/app/documentation/[...slug]/_components/documentationRouter/DocumentationClient.tsx
+++ b/src/app/documentation/[...slug]/_components/documentationRouter/DocumentationClient.tsx
@@ -7,6 +7,7 @@ import Markdown from '@/design-system/utils/Markdown'
 import { useClientTranslation } from '@/hooks/useClientTranslation'
 import { useEngine } from '@/publicodes-state'
 import { SuppportedRegions } from '@/types/international'
+import { decodeRuleNameFromPath } from '@/utils/decodeRuleNameFromPath'
 import { RulePage } from '@publicodes/react-ui'
 import Head from 'next/head'
 import Engine from 'publicodes'
@@ -18,7 +19,7 @@ type Props = {
 export default function DocumentationClient({ slugs }: Props) {
   const { i18n } = useClientTranslation()
 
-  const path = decodeURI(slugs.join('/'))
+  const path = decodeRuleNameFromPath(slugs.join('/'))
 
   const { engine } = useEngine()
 

--- a/src/utils/decodeRuleNameFromPath.ts
+++ b/src/utils/decodeRuleNameFromPath.ts
@@ -1,6 +1,5 @@
+import { utils } from 'publicodes'
+
 export function decodeRuleNameFromPath(path: string) {
-  return decodeURI(path)
-    ?.replaceAll('/', ' . ')
-    .replaceAll('\u2011', '-') // replace with a insecable tiret to differenciate from space
-    .replaceAll('-', ' ')
+  return utils.decodeRuleName(path)
 }


### PR DESCRIPTION
When trying to refresh on a URL containing a `\u2011` character (e.g. https://nosgestesclimat.fr/documentation/futureco%E2%80%91data/transport/ferry/cabines-nécessaires), I get a 404.

> [!NOTE]
> There is some styling issues markdown code blocs in imported rule descriptions:
> ![image](https://github.com/incubateur-ademe/nosgestesclimat-site-nextjs/assets/44124798/a6b3321e-e152-4ab3-a3a3-25f0bf00bce6)
 