### PR TITLE
Fix empty computed results + sanitize situation on init [NGC-809]

### DIFF
--- a/src/publicodes-state/providers/simulationProvider/useEngineSituation.ts
+++ b/src/publicodes-state/providers/simulationProvider/useEngineSituation.ts
@@ -32,9 +32,13 @@ export function useEngineSituation({ engine, everyRules }: Props) {
   useEffect(() => {
     if (isInitialized) return
 
-    engine.setSituation(situation)
+    const safeSituation = safeGetSituation({
+      situation: situation,
+      everyRules,
+    })
+    engine.setSituation(safeSituation)
     setIsInitialized(true)
-  }, [engine, situation, isInitialized])
+  }, [engine, situation, isInitialized, everyRules])
 
   return { isInitialized, addToEngineSituation }
 }

--- a/src/publicodes-state/providers/simulationProvider/useSetComputedResults.ts
+++ b/src/publicodes-state/providers/simulationProvider/useSetComputedResults.ts
@@ -34,7 +34,10 @@ export function useSetComputedResults({ categories, safeEvaluate }: Props) {
   )
 
   // Update the simulation with the computed results (only if the computed results have changed)
-  const prevComputedResults = useRef<ComputedResults>(computedResults)
+  const prevComputedResults = useRef<ComputedResults>({
+    bilan: 0,
+    categories: {},
+  })
   useEffect(() => {
     if (prevComputedResults.current === computedResults) return
 


### PR DESCRIPTION
2 fix: 
- Les computedResults n'étaient pas définis tant que l'on ne [sélectionnait](url) pas de réponse.
- La situation n'était pas cleané à l'init (donc si on avait des règles non migrées dans le localstorage ça plantait