### PR TITLE
Fix engine init

### DIFF
--- a/src/app/(layout-with-navigation)/(simulation)/infos/commencer/page.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/infos/commencer/page.tsx
@@ -161,7 +161,7 @@ export default function Commencer() {
                     postalCode,
                     birthdate,
                   },
-                  poll: pollSlug || undefined,
+                  polls: [pollSlug || ''],
                 },
               })
             }}>

--- a/src/components/providers/Providers.tsx
+++ b/src/components/providers/Providers.tsx
@@ -3,7 +3,7 @@
 import LocalisationBanner from '@/components/translation/LocalisationBanner'
 import Loader from '@/design-system/layout/Loader'
 import { useRules } from '@/hooks/useRules'
-import { SimulationProvider } from '@/publicodes-state'
+import { SimulationProvider, useCurrentSimulation } from '@/publicodes-state'
 import { SupportedRegions } from '@incubateur-ademe/nosgestesclimat'
 import { usePathname } from 'next/navigation'
 import { PropsWithChildren } from 'react'
@@ -22,6 +22,8 @@ export default function Providers({
   isOptim = true,
 }: PropsWithChildren<Props>) {
   const pathname = usePathname()
+
+  const { id } = useCurrentSimulation()
 
   const { data: rules, isLoading } = useRules({ isOptim })
 
@@ -46,11 +48,13 @@ export default function Providers({
   }
 
   return (
-    <SimulationProvider
-      rules={rules}
-      shouldAlwaysDisplayChildren={shouldAlwaysDisplayChildren}>
-      <LocalisationBanner supportedRegions={supportedRegions} />
-      {children}
-    </SimulationProvider>
+    <div key={id}>
+      <SimulationProvider
+        rules={rules}
+        shouldAlwaysDisplayChildren={shouldAlwaysDisplayChildren}>
+        <LocalisationBanner supportedRegions={supportedRegions} />
+        {children}
+      </SimulationProvider>
+    </div>
   )
 }

--- a/src/hooks/navigation/useSimulateurPage.ts
+++ b/src/hooks/navigation/useSimulateurPage.ts
@@ -1,6 +1,6 @@
 import { getLinkToSimulateur } from '@/helpers/navigation/simulateurPages'
 import { useCurrentSimulation, useUser } from '@/publicodes-state'
-import { Situation } from '@/publicodes-state/types'
+import { Simulation } from '@/publicodes-state/types'
 import { useRouter } from 'next/navigation'
 import { useCallback, useMemo } from 'react'
 import { useClientTranslation } from '../useClientTranslation'
@@ -8,14 +8,7 @@ import { useEndPage } from './useEndPage'
 
 type GoToSimulateurPageProps = {
   noNavigation?: boolean
-  newSimulation?: {
-    situation?: Situation
-    persona?: string
-    foldedSteps?: string[]
-    defaultAdditionalQuestionsAnswers?: Record<string, string>
-    poll?: string
-    group?: string
-  }
+  newSimulation?: Partial<Simulation>
 }
 const goToSimulateurPagePropsDefault = {
   noNavigation: false,


### PR DESCRIPTION
2 fix : 
- On réinitialise tout SimulationProvider au changement de simulation. Ça corrige le bug du lien avec sid et le bug de recommencer depuis profil
- On ajoute maintenant correctement le poll à la simulation lorsque l'on clique sur "Commencer un nouveau test" 