### PR TITLE
Personas et paramètre PR (NGC-848)

### DIFF
--- a/src/app/(layout-with-navigation)/(pages-statiques)/international/page.tsx
+++ b/src/app/(layout-with-navigation)/(pages-statiques)/international/page.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata() {
 export default async function International() {
   const { t } = await getServerTranslation()
 
-  const supportedRegions = await getSupportedRegions()
+  const supportedRegions = getSupportedRegions()
 
   // TODO: add back full width somehow
   return (

--- a/src/app/(layout-with-navigation)/(simulation)/layout.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/layout.tsx
@@ -2,10 +2,8 @@ import Providers from '@/components/providers/Providers'
 import { getSupportedRegions } from '@/helpers/modelFetching/getSupportedRegions'
 import { PropsWithChildren } from 'react'
 
-export default async function SimulateurLayout({
-  children,
-}: PropsWithChildren) {
-  const supportedRegions = await getSupportedRegions()
+export default function SimulateurLayout({ children }: PropsWithChildren) {
+  const supportedRegions = getSupportedRegions()
 
   return <Providers supportedRegions={supportedRegions}>{children}</Providers>
 }

--- a/src/app/(layout-with-navigation)/(simulation)/profil/page.tsx
+++ b/src/app/(layout-with-navigation)/(simulation)/profil/page.tsx
@@ -28,7 +28,7 @@ export async function generateMetadata() {
 }
 
 export default async function Profil() {
-  const supportedRegions = await getSupportedRegions()
+  const supportedRegions = getSupportedRegions()
   const { t } = await getServerTranslation()
 
   return (

--- a/src/app/(layout-with-navigation)/personas/_components/Persona.tsx
+++ b/src/app/(layout-with-navigation)/personas/_components/Persona.tsx
@@ -6,6 +6,7 @@ import Card from '@/design-system/layout/Card'
 import { useSimulation, useUser } from '@/publicodes-state'
 import { DottedName } from '@/publicodes-state/types'
 import { Persona as PersonaType } from '@incubateur-ademe/nosgestesclimat'
+import { useRouter } from 'next/navigation'
 import { fixSituationWithPartialMosaic } from '../_helpers/fixSituationWithPartialMosaic'
 import { getPersonaFoldedSteps } from '../_helpers/getPersonaFoldedSteps'
 
@@ -15,6 +16,8 @@ type Props = {
 }
 
 export default function Persona({ persona, personaDottedName }: Props) {
+  const router = useRouter()
+
   const { initSimulation, hideTutorial, currentSimulation } = useUser()
 
   const {
@@ -72,7 +75,7 @@ export default function Persona({ persona, personaDottedName }: Props) {
               progression: 1,
             })
             hideTutorial('testIntro')
-            addToEngineSituation(fixedSituation)
+            router.refresh()
           }}>
           <Trans>Sélectionner</Trans>
         </Button>

--- a/src/app/(layout-with-navigation)/personas/_components/Persona.tsx
+++ b/src/app/(layout-with-navigation)/personas/_components/Persona.tsx
@@ -3,11 +3,7 @@
 import Trans from '@/components/translation/Trans'
 import Button from '@/design-system/inputs/Button'
 import Card from '@/design-system/layout/Card'
-import {
-  useCurrentSimulation,
-  useSimulation,
-  useUser,
-} from '@/publicodes-state'
+import { useSimulation, useUser } from '@/publicodes-state'
 import { DottedName } from '@/publicodes-state/types'
 import { Persona as PersonaType } from '@incubateur-ademe/nosgestesclimat'
 import { fixSituationWithPartialMosaic } from '../_helpers/fixSituationWithPartialMosaic'
@@ -19,9 +15,7 @@ type Props = {
 }
 
 export default function Persona({ persona, personaDottedName }: Props) {
-  const { initSimulation, hideTutorial } = useUser()
-
-  const currentSimulation = useCurrentSimulation()
+  const { initSimulation, hideTutorial, currentSimulation } = useUser()
 
   const {
     everyMosaicChildrenWithParent,
@@ -30,6 +24,7 @@ export default function Persona({ persona, personaDottedName }: Props) {
     pristineEngine,
     safeEvaluate,
     safeGetRule,
+    addToEngineSituation,
   } = useSimulation()
 
   const isCurrentPersonaSelected =
@@ -56,13 +51,14 @@ export default function Persona({ persona, personaDottedName }: Props) {
           className="align-self-end mt-auto"
           disabled={isCurrentPersonaSelected}
           onClick={() => {
+            const fixedSituation = fixSituationWithPartialMosaic({
+              situation: persona.situation,
+              everyMosaicChildrenWithParent,
+              safeGetRule,
+              safeEvaluate,
+            })
             initSimulation({
-              situation: fixSituationWithPartialMosaic({
-                situation: persona.situation,
-                everyMosaicChildrenWithParent,
-                safeGetRule,
-                safeEvaluate,
-              }),
+              situation: fixedSituation,
               persona: personaDottedName,
               foldedSteps: getPersonaFoldedSteps({
                 situation: persona.situation,
@@ -73,8 +69,10 @@ export default function Persona({ persona, personaDottedName }: Props) {
                 safeGetRule,
                 safeEvaluate,
               }),
+              progression: 1,
             })
             hideTutorial('testIntro')
+            addToEngineSituation(fixedSituation)
           }}>
           <Trans>Sélectionner</Trans>
         </Button>

--- a/src/app/(layout-with-navigation)/personas/_components/Persona.tsx
+++ b/src/app/(layout-with-navigation)/personas/_components/Persona.tsx
@@ -28,7 +28,6 @@ export default function Persona({ persona, personaDottedName }: Props) {
     everyRules,
     safeEvaluate,
     safeGetRule,
-    addToEngineSituation,
   } = useSimulation()
 
   const isCurrentPersonaSelected =

--- a/src/app/(layout-with-navigation)/personas/layout.tsx
+++ b/src/app/(layout-with-navigation)/personas/layout.tsx
@@ -18,8 +18,8 @@ export async function generateMetadata() {
   })
 }
 
-export default async function PersonasLayout({ children }: PropsWithChildren) {
-  const supportedRegions = await getSupportedRegions()
+export default function PersonasLayout({ children }: PropsWithChildren) {
+  const supportedRegions = getSupportedRegions()
 
   return <Providers supportedRegions={supportedRegions}>{children}</Providers>
 }

--- a/src/app/(layout-with-navigation)/personas/layout.tsx
+++ b/src/app/(layout-with-navigation)/personas/layout.tsx
@@ -1,0 +1,25 @@
+import Providers from '@/components/providers/Providers'
+import { getServerTranslation } from '@/helpers/getServerTranslation'
+import { getMetadataObject } from '@/helpers/metadata/getMetadataObject'
+import { getSupportedRegions } from '@/helpers/modelFetching/getSupportedRegions'
+import { PropsWithChildren } from 'react'
+
+export async function generateMetadata() {
+  const { t } = await getServerTranslation()
+
+  return getMetadataObject({
+    title: t("Nos personas d'utilisateurs types - Nos Gestes Climat"),
+    description: t(
+      "Découvrez les personas d'utilisateurs types qui nous servent à tester le simulateur sous toutes ses coutures."
+    ),
+    alternates: {
+      canonical: '/personas',
+    },
+  })
+}
+
+export default async function PersonasLayout({ children }: PropsWithChildren) {
+  const supportedRegions = await getSupportedRegions()
+
+  return <Providers supportedRegions={supportedRegions}>{children}</Providers>
+}

--- a/src/app/(layout-with-navigation)/personas/page.tsx
+++ b/src/app/(layout-with-navigation)/personas/page.tsx
@@ -1,38 +1,16 @@
-import Providers from '@/components/providers/Providers'
+'use client'
+
 import Trans from '@/components/translation/Trans'
 import Title from '@/design-system/layout/Title'
-import { getServerTranslation } from '@/helpers/getServerTranslation'
-import { getMetadataObject } from '@/helpers/metadata/getMetadataObject'
-import { getPersonas } from '@/helpers/modelFetching/getPersonas'
-import { getSupportedRegions } from '@/helpers/modelFetching/getSupportedRegions'
+import { usePersonas } from '@/hooks/usePersonas'
 import PersonaExplanations from './_components/PersonaExplanations'
 import PersonaList from './_components/PersonaList'
 
-export async function generateMetadata() {
-  const { t } = await getServerTranslation()
-
-  return getMetadataObject({
-    title: t("Nos personas d'utilisateurs types - Nos Gestes Climat"),
-    description: t(
-      "Découvrez les personas d'utilisateurs types qui nous servent à tester le simulateur sous toutes ses coutures."
-    ),
-    alternates: {
-      canonical: '/personas',
-    },
-  })
-}
-
-type Props = {
-  params: {
-    locale: string
-  }
-}
-export default async function Personas({ params: { locale } }: Props) {
-  const supportedRegions = await getSupportedRegions()
-  const personas = await getPersonas({ locale })
+export default function Personas() {
+  const { data: personas, isFetched } = usePersonas()
 
   return (
-    <Providers supportedRegions={supportedRegions}>
+    <>
       <Title title={<Trans>Personas</Trans>} data-cypress-id="personas-title" />
       <p>
         <Trans>
@@ -50,8 +28,8 @@ export default async function Personas({ params: { locale } }: Props) {
           comme si vous étiez l'un des profils types que nous avons listés.
         </Trans>
       </p>
-      <PersonaList personas={personas} />
+      {isFetched && personas ? <PersonaList personas={personas} /> : null}
       <PersonaExplanations />
-    </Providers>
+    </>
   )
 }

--- a/src/app/documentation/[...slug]/page.tsx
+++ b/src/app/documentation/[...slug]/page.tsx
@@ -26,12 +26,12 @@ export async function generateMetadata({
 
 // The page content is in layout.tsx in order to persist the state
 // between the server and the client
-export default async function DocumentationPage({
+export default function DocumentationPage({
   params: { slug },
 }: {
   params: { slug: string[] }
 }) {
-  const supportedRegions = await getSupportedRegions()
+  const supportedRegions = getSupportedRegions()
 
   return (
     <DocumentationRouter

--- a/src/helpers/modelFetching/getRules.ts
+++ b/src/helpers/modelFetching/getRules.ts
@@ -24,7 +24,7 @@ export async function getRules({
   locale = 'fr',
   PRNumber,
 }: Props = defaultProps): Promise<NGCRules> {
-  const supportedRegions = await getSupportedRegions()
+  const supportedRegions = getSupportedRegions()
 
   // We provide the FR version of the model if the region is not supported
   const regionCodeToProvide = supportedRegions[regionCode] ? regionCode : 'FR'

--- a/src/helpers/modelFetching/getSupportedRegions.ts
+++ b/src/helpers/modelFetching/getSupportedRegions.ts
@@ -4,6 +4,6 @@ import supportedRegions from '@incubateur-ademe/nosgestesclimat/public/supported
 /**
  * This function is used to get the supported regions. It can be called directly from a server component.
  */
-export async function getSupportedRegions(): Promise<SupportedRegions> {
-  return Promise.resolve(supportedRegions)
+export function getSupportedRegions(): SupportedRegions {
+  return supportedRegions
 }

--- a/src/hooks/usePersonas.ts
+++ b/src/hooks/usePersonas.ts
@@ -17,6 +17,6 @@ export function usePersonas(): UseQueryResult<Personas, Error> {
     queryKey: ['personas', locale, PRNumber],
     queryFn: () => getPersonas({ locale, PRNumber }),
     placeholderData: keepPreviousData,
-    staleTime: 5000000000, // We don't want to import the personas multiple times
+    staleTime: Infinity, // We don't want to import the personas multiple times
   })
 }

--- a/src/hooks/usePersonas.ts
+++ b/src/hooks/usePersonas.ts
@@ -1,0 +1,22 @@
+import { getPersonas } from '@/helpers/modelFetching/getPersonas'
+import { Personas } from '@incubateur-ademe/nosgestesclimat'
+import {
+  UseQueryResult,
+  keepPreviousData,
+  useQuery,
+} from '@tanstack/react-query'
+import { useLocale } from './useLocale'
+import { usePRNumber } from './usePRNumber'
+
+export function usePersonas(): UseQueryResult<Personas, Error> {
+  const locale = useLocale()
+
+  const { PRNumber } = usePRNumber()
+
+  return useQuery({
+    queryKey: ['rules', locale, PRNumber],
+    queryFn: () => getPersonas({ locale, PRNumber }),
+    placeholderData: keepPreviousData,
+    staleTime: 5000000000, // We don't want to import the rule multiple times
+  })
+}

--- a/src/hooks/useRules.ts
+++ b/src/hooks/useRules.ts
@@ -31,6 +31,6 @@ export function useRules(
     queryKey: ['rules', locale, regionCode, isOptim, PRNumber],
     queryFn: () => getRules({ locale, regionCode, isOptim, PRNumber }),
     placeholderData: keepPreviousData,
-    staleTime: 5000000000, // We don't want to import the rule multiple times
+    staleTime: Infinity, // We don't want to import the rule multiple times
   })
 }

--- a/src/publicodes-state/hooks/useDisposableEngine/index.ts
+++ b/src/publicodes-state/hooks/useDisposableEngine/index.ts
@@ -18,6 +18,7 @@ export default function useDisposableEngine({ rules, situation }: Props) {
 
   const engine = useMemo(() => {
     return new Engine(rules ?? contextRules, {
+      logger: { warn: () => {}, error: () => {}, log: () => {} },
       strict: {
         situation: false,
         noOrphanRule: false,

--- a/src/publicodes-state/hooks/useSimulation/index.ts
+++ b/src/publicodes-state/hooks/useSimulation/index.ts
@@ -16,6 +16,7 @@ export default function useSimulation() {
     safeEvaluate,
     safeGetRule,
     isInitialized,
+    addToEngineSituation,
   } = useContext(SimulationContext)
 
   return {
@@ -29,5 +30,6 @@ export default function useSimulation() {
     safeEvaluate,
     safeGetRule,
     isInitialized,
+    addToEngineSituation,
   }
 }


### PR DESCRIPTION
Je me demande si on touche pas au pb plus large de la `situation`: on a 2 états de la situation différents (l’engine et le localstorage)

J'ai aussi un souci avec les computedResults : sur la page persona, ils prennent la bonne valeur mais quand je bascule sur l'empreinte, on récupère la valeur par défaut ..

Acuellement, on a toujours un bug avec une PR et une sélection de persona (ce qui arrive assez souvent). j'ai essayé (mais j'ose pas poussé les modifs pour l'instant, je crois que c'est pas propre):

- utiliser autre chose de `pristineEngine` dans `getPersonaFoldedSteps`
- gérer l'import des fichiers de la review pour les personas, le fichier de migration (pas le cas actuellement)