### PR TITLE
:sparkles: linux magic key shortcut (NGC-1082)

### DIFF
--- a/src/hooks/useMagicKey.ts
+++ b/src/hooks/useMagicKey.ts
@@ -7,7 +7,7 @@ export function useMagicKey({
 }) {
   useEffect(() => {
     const handleMagicKey = async (e: KeyboardEvent) => {
-      if (e.altKey && e.key === 'Escape') {
+      if (e.altKey && (e.key === 'Escape' || e.key === 'Enter')) {
         await gotToNextQuestion(e)
       }
     }


### PR DESCRIPTION
Cette PR ajoute le raccourci `Alt + Entrée` sur le test pour les utilisateurs non mac OS