### PR TITLE
:bricks: do not pay vercel middleware for static assets and api (NGC-1108)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -32,3 +32,27 @@ function isRewriting(response: NextResponse): boolean {
 function isI18n(response: NextResponse): boolean {
   return response.headers.has('x-next-i18n-router-locale')
 }
+
+/**
+ * Evite que le middleware soit appliqué à certaines routes
+ */
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - images (image optimization files)
+     * - favicon.ico (favicon file)
+     * - manifest.webmanifest (manifest file)
+     */
+    {
+      source:
+        '/((?!api|_next/static|favicon.ico|images|manifest.webmanifest).*)',
+      missing: [
+        { type: 'header', key: 'next-router-prefetch' },
+        { type: 'header', key: 'purpose', value: 'prefetch' },
+      ],
+    },
+  ],
+}


### PR DESCRIPTION
Le but de cette PR est de désactiver l'exécution du middleware sur vercel pour les requêtes vers des assets statiques et les routes api.

Référence
 - https://vercel.com/docs/pricing/edge-middleware#optimizing-middleware-invocations
 - https://vercel.com/docs/functions/edge-middleware/middleware-api#match-based-on-a-negative-lookahead 