### PR TITLE
:bug: change locale after landing on en / es (NGC-958)

### DIFF
--- a/src/components/translation/LanguageSwitchButton.tsx
+++ b/src/components/translation/LanguageSwitchButton.tsx
@@ -8,13 +8,11 @@ import { useIframe } from '@/hooks/useIframe'
 import i18nConfig from '@/i18nConfig'
 import { trackEvent } from '@/utils/matomo/trackEvent'
 import { useCurrentLocale } from 'next-i18n-router/client'
-import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { usePathname, useSearchParams } from 'next/navigation'
 import { useCallback, useEffect } from 'react'
 
 export default function LanguageSwitchButton() {
   const { t } = useClientTranslation()
-
-  const router = useRouter()
 
   const currentPathname = usePathname()
 
@@ -47,22 +45,18 @@ export default function LanguageSwitchButton() {
       updateCookie(newLocale)
 
       if (currentLocale === i18nConfig.defaultLocale) {
-        router.push(
+        window.location.href =
           '/' +
-            newLocale +
-            currentPathname +
-            (searchParams.length > 0 ? `?${searchParams}` : '')
-        )
+          newLocale +
+          currentPathname +
+          (searchParams.length > 0 ? `?${searchParams}` : '')
       } else {
-        router.push(
+        window.location.href =
           currentPathname.replace(`/${currentLocale}`, `/${newLocale}`) +
-            (searchParams.length > 0 ? `?${searchParams}` : '')
-        )
+          (searchParams.length > 0 ? `?${searchParams}` : '')
       }
-
-      router.refresh()
     },
-    [currentLocale, currentPathname, router, searchParams]
+    [currentLocale, currentPathname, searchParams]
   )
 
   // If the lang is fixed by the iframe and is not the same as the current locale, we change it here


### PR DESCRIPTION
L' erreur est due au fait que quand on arrive sur `/en` puis qu' on change la langue en `fr`  les requêtes sont

`GET /fr` => `307 /`
`GET /` => `200`
`GET /?_rsc=1iwkq` => `200`
`GET /en?_rsc=1iwkq` => C'est cette requête qui actualise les serverComponents et les repasse en anglais

J'ai essayé énormément de choses
 - Tweak le middleware i18n pour jouer avec le cookie `NEXT_LOCALE` => impossible d'identifier la requête qui reste en `/en` avec les paramètres passés au middleware
 - Passer `next-i18n-router` en v5 => `currentLocale` disparait => grosse refacto
 - Solution cookie  `NEXT_LOCALE` si le cookie est là, on le considère par dessus tout => problème, on peut naviguer vers `/en` avec un cookie `fr` et afficher la page en francais car une fois de plus, pas moyen d'identifier la requête dans le middleware
 - Refresh la page => solution proposée tout fonctionne comme demandé mais ca fait un full refresh...
 
 J'ai pas mieux pour le moment. Il faudrait ouvrir une issue sur `next-i18n-router` mais pas sur qu'ils fixent leur v4... Voir si c'est toujours le cas en v5 et prévoir le bump... 