### PR TITLE
Update metabase URL

### DIFF
--- a/src/app/(large-layout)/northstar/_components/NorthStarIframe.tsx
+++ b/src/app/(large-layout)/northstar/_components/NorthStarIframe.tsx
@@ -25,7 +25,7 @@ export default function NorthStarIframe() {
         ref={iFrameRef}
         id="iframe-metabase-northstar"
         title="Statistiques Northstar Metabase"
-        src="https://metabase-ngc.osc-fr1.scalingo.io/public/dashboard/0f6974c5-1254-47b4-b6d9-6e6f22a6faf7"
+        src="https://metabase.nosgestesclimat.fr/public/dashboard/0f6974c5-1254-47b4-b6d9-6e6f22a6faf7"
         width="100%"
         height="1800px"
         className="border-none"></iframe>

--- a/src/app/(large-layout)/stats/_components/StatsContent.tsx
+++ b/src/app/(large-layout)/stats/_components/StatsContent.tsx
@@ -153,7 +153,7 @@ export default function StatsContent() {
         <MetabaseIframe
           id="stats-quali"
           titre="stats-quali"
-          src="https://metabase-ngc.osc-fr1.scalingo.io/public/dashboard/f36c5cc4-abb9-4ac6-98b5-13bed7318e7d#titled=false"
+          src="https://metabase.nosgestesclimat.fr/public/dashboard/f36c5cc4-abb9-4ac6-98b5-13bed7318e7d#titled=false"
           height="800px"
         />{' '}
       </div>
@@ -172,13 +172,13 @@ export default function StatsContent() {
         <MetabaseIframe
           id="stats-orga"
           titre="stats mode orga"
-          src="https://metabase-ngc.osc-fr1.scalingo.io/public/dashboard/f64f2de4-fc94-431e-a6c0-01f9c0095267#titled=false"
+          src="https://metabase.nosgestesclimat.fr/public/dashboard/f64f2de4-fc94-431e-a6c0-01f9c0095267#titled=false"
         />
         <h3 className="mt-4">Mode "Challenge tes amis"</h3>
         <MetabaseIframe
           id="stats-amis"
           titre="stats-amis"
-          src="https://metabase-ngc.osc-fr1.scalingo.io/public/dashboard/8a32d8a6-3716-40a7-9ce0-f9991c54acf4#titled=false"
+          src="https://metabase.nosgestesclimat.fr/public/dashboard/8a32d8a6-3716-40a7-9ce0-f9991c54acf4#titled=false"
         />{' '}
       </div>
     </div>


### PR DESCRIPTION
Stat page isn't working anymore:
![image](https://github.com/user-attachments/assets/fd4863f6-4f09-4550-b095-ccbb94812176)


=> Use `metabase.nosgestesclimat.fr`