### PR TITLE
:bug: Harmonize filtering between orga view and poll view

### DIFF
--- a/src/app/(simulation)/(large-layout)/organisations/[orgaSlug]/_components/myPolls/PollCard.tsx
+++ b/src/app/(simulation)/(large-layout)/organisations/[orgaSlug]/_components/myPolls/PollCard.tsx
@@ -1,5 +1,6 @@
 import Trans from '@/components/translation/Trans'
 import ButtonLink from '@/design-system/inputs/ButtonLink'
+import { filterExtremes } from '@/helpers/organisations/filterExtremes'
 import { OrganisationPoll } from '@/types/organisations'
 import dayjs from 'dayjs'
 import { useParams } from 'next/navigation'
@@ -13,6 +14,8 @@ export default function PollCard({ poll }: Props) {
   const { orgaSlug } = useParams()
 
   if (!poll) return null
+
+  const simulationsWithoutExtremes = filterExtremes(poll.simulations)
 
   return (
     <div className="rounded-xl bg-primary-50 p-6">
@@ -37,7 +40,7 @@ export default function PollCard({ poll }: Props) {
         </p>
 
         <p className="text-base font-light text-default">
-          {poll.simulations?.length > 1 ? (
+          {simulationsWithoutExtremes?.length > 1 ? (
             <Trans>Simulations terminées</Trans>
           ) : (
             <Trans>Simulation terminée</Trans>

--- a/src/app/(simulation)/(large-layout)/organisations/[orgaSlug]/campagnes/[pollSlug]/page.tsx
+++ b/src/app/(simulation)/(large-layout)/organisations/[orgaSlug]/campagnes/[pollSlug]/page.tsx
@@ -8,6 +8,7 @@ import { filterExtremes } from '@/helpers/organisations/filterExtremes'
 import { filterSimulationRecaps } from '@/helpers/organisations/filterSimulationRecaps'
 import { useFetchPollData } from '@/hooks/organisations/useFetchPollData'
 import { useHandleRedirectFromLegacy } from '@/hooks/organisations/useHandleRedirectFromLegacy'
+import { SimulationRecap } from '@/types/organisations'
 import dayjs from 'dayjs'
 import { useParams, useSearchParams } from 'next/navigation'
 import { useContext, useMemo } from 'react'
@@ -47,7 +48,7 @@ export default function CampagnePage() {
   const filteredSimulationRecaps =
     pollData &&
     filterSimulationRecaps({
-      simulationRecaps: simulationRecapsWithoutExtremes,
+      simulationRecaps: simulationRecapsWithoutExtremes as SimulationRecap[],
       ageFilters,
       postalCodeFilters,
     })
@@ -103,13 +104,17 @@ export default function CampagnePage() {
 
         <PollStatistics
           simulationRecaps={pollData?.simulationRecaps ?? []}
-          simulationRecapsWithoutExtremes={simulationRecapsWithoutExtremes}
+          simulationRecapsWithoutExtremes={
+            simulationRecapsWithoutExtremes as SimulationRecap[]
+          }
           funFacts={pollData?.funFacts}
           title={<Trans>Résultats de campagne</Trans>}
         />
 
         <PollStatisticsFilters
-          simulationRecaps={simulationRecapsWithoutExtremes ?? []}
+          simulationRecaps={
+            simulationRecapsWithoutExtremes as SimulationRecap[]
+          }
           filteredSimulationRecaps={filteredSimulationRecaps ?? []}
           defaultAdditionalQuestions={
             pollData?.defaultAdditionalQuestions ?? []

--- a/src/helpers/organisations/filterExtremes.ts
+++ b/src/helpers/organisations/filterExtremes.ts
@@ -1,9 +1,12 @@
 import { carboneMetric } from '@/constants/metric'
+import { Simulation } from '@/publicodes-state/types'
 import { SimulationRecap } from '@/types/organisations'
 
 const MAX_VALUE = 100000
 
-export function filterExtremes(simulationRecaps: SimulationRecap[]) {
+export function filterExtremes(
+  simulationRecaps: (SimulationRecap | Simulation)[]
+) {
   return simulationRecaps.filter((simulationRecap) => {
     // Remove simulations with too high values
     if (


### PR DESCRIPTION
@paulsouche ici je me demande si :
* le filtrage des simulations avec des valeurs extrêmes ne devrait pas plutôt se faire côté back ;
* on ne devrait pas avoir des routes distinctes pour afficher les listes, qui renverraient un `simulationCount` plutôt que de passer toutes les simulations et faire le compte côté front.

Globalement y'a pas mal d'améliorations à faire de ce type ce serait bien qu'on se passe ça en revue.