### PR TITLE
🐛 Set `logement . chauffage . bois . type` as priority (NGC-684)

### DIFF
--- a/src/publicodes-state/providers/formProvider/useQuestions.ts
+++ b/src/publicodes-state/providers/formProvider/useQuestions.ts
@@ -33,7 +33,10 @@ export default function useQuestions({
   rawMissingVariables,
 }: Props) {
   // We use the DottedName type from nosgestesclimat to make sure the build will break when using rules that are not in the model.
-  const priorityQuestions: DottedName[] = ['alimentation . plats']
+  const priorityQuestions: DottedName[] = [
+    'alimentation . plats',
+    'logement . chauffage . bois . type',
+  ]
 
   const nonPriorityQuestions: DottedName[] = [
     'logement . électricité . réseau . consommation',


### PR DESCRIPTION
I have no explanation why missing variable score for `logement . chauffage . bois . type` is so low.